### PR TITLE
feat: Alt+Left/Right directory history navigation (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Insert      Toggle select current file
 *           Invert selection
 /           Quick search in current panel
 Alt+Enter   Insert filename into command line
+Alt+Left    Back through directory history
+Alt+Right   Forward through directory history
 Alt+O       Open in Finder (macOS only)
 Shift+F3    Cycle sort order (name/size/date/extension)
 Ctrl+F3     Toggle reverse sort (terminal-dependent)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ chmod +x tnc
 | `*` | Invert selection |
 | `/` | Quick search |
 | `Alt+Enter` | Insert filename into command line |
+| `Alt+←` | Back through directory history |
+| `Alt+→` | Forward through directory history |
 | `Shift+F3` | Cycle sort order (name/size/date/extension) |
 | `Ctrl+F3` | Toggle reverse sort (terminal-dependent) |
 | `Shift+F4` | Create new file (opens in editor) |

--- a/tests/test_back_forward_navigation.py
+++ b/tests/test_back_forward_navigation.py
@@ -241,3 +241,44 @@ class TestAltLeftRightHandling(unittest.TestCase):
         action = self._press_alt(curses.KEY_LEFT)
         self.assertEqual(action, Action.NONE)
         self.assertEqual(self.app.active_panel.path, original_path)
+
+    def test_alt_left_actually_changes_panel_path_end_to_end(self) -> None:
+        # No mocks on the panel: populate the back stack via a real navigation,
+        # then press Alt+Left and assert the panel and command line both moved.
+        root = Path(self.tmp.name).resolve()
+        (root / 'sub').mkdir()
+        self.app.active_panel.change_directory(root / 'sub')
+        self.assertEqual(self.app.active_panel.path, root / 'sub')
+
+        self._press_alt(curses.KEY_LEFT)
+
+        self.assertEqual(self.app.active_panel.path, root)
+        self.assertEqual(self.app.command_line.path, str(root))
+
+    def test_panel_switch_preserves_each_panels_history(self) -> None:
+        # Navigate on the active (left) panel, switch to right, navigate there,
+        # switch back, and confirm Alt+Left still reflects the left panel's
+        # private history.
+        root = Path(self.tmp.name).resolve()
+        (root / 'left_child').mkdir()
+        (root / 'right_child').mkdir()
+
+        # Build history on the left panel.
+        self.app.active_panel.change_directory(root / 'left_child')
+        self.assertEqual(self.app.active_panel.path, root / 'left_child')
+        left_back_before_switch = list(self.app.left_panel._back_stack)
+
+        # Switch to right panel and navigate independently.
+        self.app.switch_panel()
+        self.assertIs(self.app.active_panel, self.app.right_panel)
+        self.app.active_panel.change_directory(root / 'right_child')
+
+        # Switch back to left and confirm its stack is untouched by the right's nav.
+        self.app.switch_panel()
+        self.assertIs(self.app.active_panel, self.app.left_panel)
+        self.assertEqual(self.app.left_panel._back_stack, left_back_before_switch)
+
+        # Alt+Left now walks the left panel back, not the right's.
+        self._press_alt(curses.KEY_LEFT)
+        self.assertEqual(self.app.left_panel.path, root)
+        self.assertEqual(self.app.right_panel.path, root / 'right_child')

--- a/tests/test_back_forward_navigation.py
+++ b/tests/test_back_forward_navigation.py
@@ -147,3 +147,74 @@ class TestBackForwardStack(unittest.TestCase):
         # Refresh of current path will set error_message, but that's expected.
         self.assertTrue(panel.navigate_back())
         self.assertEqual(panel.path, self.root)
+
+
+class TestAltLeftRightHandling(unittest.TestCase):
+    """App-level Alt+Left / Alt+Right key routing."""
+
+    def setUp(self) -> None:
+        self.patches = [
+            mock.patch('curses.has_colors', return_value=False),
+            mock.patch('curses.curs_set'),
+        ]
+        for p in self.patches:
+            p.start()
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cwd_patch = mock.patch('os.getcwd', return_value=self.tmp.name)
+        self.cwd_patch.start()
+
+        self.app = App(create_mock_stdscr())
+        self.app.setup()
+
+    def tearDown(self) -> None:
+        self.cwd_patch.stop()
+        self.tmp.cleanup()
+        for p in self.patches:
+            p.stop()
+
+    def _press_alt(self, follow_up_key: int) -> Action:
+        """Simulate Alt+<follow_up_key> via the Esc-prefix sequence."""
+        self.app.stdscr.nodelay.return_value = None
+        self.app.stdscr.getch.return_value = follow_up_key
+        return self.app.handle_key(27)  # Escape
+
+    def test_alt_left_calls_active_panel_navigate_back(self) -> None:
+        with mock.patch.object(self.app.active_panel, 'navigate_back') as mock_back, \
+             mock.patch.object(self.app.command_line, 'set_path') as mock_set_path:
+            mock_back.return_value = True
+            self._press_alt(curses.KEY_LEFT)
+            mock_back.assert_called_once_with()
+            mock_set_path.assert_called_once_with(str(self.app.active_panel.path))
+
+    def test_alt_right_calls_active_panel_navigate_forward(self) -> None:
+        with mock.patch.object(self.app.active_panel, 'navigate_forward') as mock_fwd, \
+             mock.patch.object(self.app.command_line, 'set_path') as mock_set_path:
+            mock_fwd.return_value = True
+            self._press_alt(curses.KEY_RIGHT)
+            mock_fwd.assert_called_once_with()
+            mock_set_path.assert_called_once_with(str(self.app.active_panel.path))
+
+    def test_alt_left_returns_action_none(self) -> None:
+        action = self._press_alt(curses.KEY_LEFT)
+        self.assertEqual(action, Action.NONE)
+
+    def test_alt_right_returns_action_none(self) -> None:
+        action = self._press_alt(curses.KEY_RIGHT)
+        self.assertEqual(action, Action.NONE)
+
+    def test_plain_left_arrow_still_drives_command_line(self) -> None:
+        # Plain Left (no preceding Esc) must continue to drive the command-line cursor
+        # and must NOT call navigate_back.
+        with mock.patch.object(self.app.active_panel, 'navigate_back') as mock_back, \
+             mock.patch.object(self.app.command_line, 'handle_key') as mock_cl_key:
+            self.app.handle_key(curses.KEY_LEFT)
+            mock_back.assert_not_called()
+            mock_cl_key.assert_called_once_with(curses.KEY_LEFT)
+
+    def test_alt_left_on_empty_stack_is_silent(self) -> None:
+        # Default app state: no prior navigation, back stack empty.
+        original_path = self.app.active_panel.path
+        action = self._press_alt(curses.KEY_LEFT)
+        self.assertEqual(action, Action.NONE)
+        self.assertEqual(self.app.active_panel.path, original_path)

--- a/tests/test_back_forward_navigation.py
+++ b/tests/test_back_forward_navigation.py
@@ -1,0 +1,149 @@
+"""Tests for Alt+Left / Alt+Right back/forward directory history navigation (issue #19)."""
+
+import curses
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.helpers import create_mock_stdscr
+from tnc.app import Action, App
+from tnc.panel import Panel
+
+
+class TestBackForwardStack(unittest.TestCase):
+    """Per-panel back/forward stack semantics."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name).resolve()
+        (self.root / 'alpha').mkdir()
+        (self.root / 'beta').mkdir()
+        (self.root / 'gamma').mkdir()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_navigate_back_returns_false_on_empty_stack(self) -> None:
+        panel = Panel(str(self.root))
+        self.assertFalse(panel.navigate_back())
+        self.assertEqual(panel.path, self.root)
+
+    def test_navigate_forward_returns_false_on_empty_stack(self) -> None:
+        panel = Panel(str(self.root))
+        self.assertFalse(panel.navigate_forward())
+        self.assertEqual(panel.path, self.root)
+
+    def test_change_directory_pushes_previous_path_to_back_stack(self) -> None:
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        self.assertEqual(panel._back_stack, [self.root])
+
+    def test_change_directory_clears_forward_stack_on_manual_nav(self) -> None:
+        panel = Panel(str(self.root))
+        # Build up some forward history: root → alpha, then back.
+        panel.change_directory(self.root / 'alpha')
+        panel.navigate_back()
+        self.assertEqual(panel._forward_stack, [self.root / 'alpha'])
+
+        # Now make a manual nav to a different dir; forward must be cleared.
+        panel.change_directory(self.root / 'beta')
+        self.assertEqual(panel._forward_stack, [])
+
+    def test_navigate_back_changes_dir_and_pushes_to_forward(self) -> None:
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        self.assertTrue(panel.navigate_back())
+        self.assertEqual(panel.path, self.root)
+        self.assertEqual(panel._forward_stack, [self.root / 'alpha'])
+        self.assertEqual(panel._back_stack, [])
+
+    def test_navigate_forward_changes_dir_and_pushes_to_back(self) -> None:
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        panel.navigate_back()
+        # Pre-conditions
+        self.assertEqual(panel.path, self.root)
+        self.assertEqual(panel._forward_stack, [self.root / 'alpha'])
+
+        self.assertTrue(panel.navigate_forward())
+        self.assertEqual(panel.path, self.root / 'alpha')
+        self.assertEqual(panel._back_stack, [self.root])
+        self.assertEqual(panel._forward_stack, [])
+
+    def test_back_forward_round_trip_preserves_state(self) -> None:
+        # A (root) → B (alpha) → C (beta), back → B, back → A, forward → B, forward → C.
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        panel.change_directory(self.root / 'beta')
+        self.assertEqual(panel.path, self.root / 'beta')
+
+        self.assertTrue(panel.navigate_back())
+        self.assertEqual(panel.path, self.root / 'alpha')
+        self.assertTrue(panel.navigate_back())
+        self.assertEqual(panel.path, self.root)
+
+        self.assertTrue(panel.navigate_forward())
+        self.assertEqual(panel.path, self.root / 'alpha')
+        self.assertTrue(panel.navigate_forward())
+        self.assertEqual(panel.path, self.root / 'beta')
+
+        # After replaying all the way forward, forward stack is empty,
+        # back stack contains the full prefix.
+        self.assertEqual(panel._forward_stack, [])
+        self.assertEqual(panel._back_stack, [self.root, self.root / 'alpha'])
+
+    def test_change_directory_no_op_does_not_push(self) -> None:
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root)  # same path
+        self.assertEqual(panel._back_stack, [])
+
+    def test_back_stack_respects_size_limit(self) -> None:
+        # Create LIMIT+1 distinct directories and visit each one.
+        limit = Panel._BACK_FORWARD_LIMIT
+        dirs = []
+        for i in range(limit + 1):
+            d = self.root / f'd{i:03d}'
+            d.mkdir()
+            dirs.append(d)
+
+        panel = Panel(str(self.root))
+        for d in dirs:
+            panel.change_directory(d)
+            # Bounce off a sibling so each manual nav pushes a unique entry.
+            panel.change_directory(self.root)
+
+        # After 2*(limit+1) pushes the back stack is bounded.
+        self.assertLessEqual(len(panel._back_stack), limit)
+        # Oldest entries should have been evicted (FIFO from the front).
+        self.assertNotIn(dirs[0], panel._back_stack)
+
+    def test_panels_have_independent_stacks(self) -> None:
+        panel_a = Panel(str(self.root))
+        panel_b = Panel(str(self.root))
+        panel_a.change_directory(self.root / 'alpha')
+        # Panel B should be untouched.
+        self.assertEqual(panel_b._back_stack, [])
+        self.assertEqual(panel_b.path, self.root)
+
+    def test_dotdot_navigation_pushes_to_back_stack(self) -> None:
+        panel = Panel(str(self.root / 'alpha'))
+        # '..' is at index 0
+        panel.cursor = 0
+        panel.enter()
+        self.assertEqual(panel.path, self.root)
+        # The '..' nav is a manual change, so back stack should contain alpha.
+        self.assertEqual(panel._back_stack, [self.root / 'alpha'])
+
+    def test_navigate_back_to_missing_directory_still_navigates(self) -> None:
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        # Delete alpha while we're sitting in it
+        shutil.rmtree(self.root / 'alpha')
+
+        # Now go back to root: navigate_back() returns to a still-existing dir.
+        # First reverse the order: we're in (gone) alpha, going back lands on root.
+        # Refresh of current path will set error_message, but that's expected.
+        self.assertTrue(panel.navigate_back())
+        self.assertEqual(panel.path, self.root)

--- a/tests/test_back_forward_navigation.py
+++ b/tests/test_back_forward_navigation.py
@@ -136,17 +136,40 @@ class TestBackForwardStack(unittest.TestCase):
         # The '..' nav is a manual change, so back stack should contain alpha.
         self.assertEqual(panel._back_stack, [self.root / 'alpha'])
 
-    def test_navigate_back_to_missing_directory_still_navigates(self) -> None:
+    def test_navigate_back_from_missing_directory_returns_to_existing(self) -> None:
+        # Sitting in a directory that gets removed externally: Alt+Left should
+        # still take us to the previous (still existing) location.
         panel = Panel(str(self.root))
         panel.change_directory(self.root / 'alpha')
-        # Delete alpha while we're sitting in it
         shutil.rmtree(self.root / 'alpha')
 
-        # Now go back to root: navigate_back() returns to a still-existing dir.
-        # First reverse the order: we're in (gone) alpha, going back lands on root.
-        # Refresh of current path will set error_message, but that's expected.
         self.assertTrue(panel.navigate_back())
         self.assertEqual(panel.path, self.root)
+
+    def test_navigate_back_to_missing_target_sets_error_message(self) -> None:
+        # Now the inverse: we navigate away from a directory that later gets
+        # removed, and Alt+Left tries to return to it. We accept the path
+        # (resolve doesn't require existence) but refresh surfaces the error.
+        panel = Panel(str(self.root / 'alpha'))
+        panel.change_directory(self.root)
+        shutil.rmtree(self.root / 'alpha')
+
+        self.assertTrue(panel.navigate_back())
+        self.assertEqual(panel.path, self.root / 'alpha')
+        self.assertIsNotNone(panel.error_message)
+
+    def test_external_change_resets_back_forward_stacks(self) -> None:
+        # An external (e.g. command-line) jump is a fresh start; both stacks
+        # should be wiped so Alt+Left/Right don't pop into the prior session.
+        panel = Panel(str(self.root))
+        panel.change_directory(self.root / 'alpha')
+        panel.change_directory(self.root / 'beta')
+        # Pre-condition: stacks are populated
+        self.assertEqual(len(panel._back_stack), 2)
+
+        panel.change_directory(self.root / 'gamma', external=True)
+        self.assertEqual(panel._back_stack, [])
+        self.assertEqual(panel._forward_stack, [])
 
 
 class TestAltLeftRightHandling(unittest.TestCase):

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -438,11 +438,9 @@ class App:
                     return Action.OPEN_IN_FINDER
                 return Action.NONE
             elif next_key == curses.KEY_LEFT:
-                # Alt+Left - back through directory history
                 self.active_panel.navigate_back()
                 self.command_line.set_path(str(self.active_panel.path))
             elif next_key == curses.KEY_RIGHT:
-                # Alt+Right - forward through directory history
                 self.active_panel.navigate_forward()
                 self.command_line.set_path(str(self.active_panel.path))
             elif next_key != -1:

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -437,6 +437,14 @@ class App:
                 if sys.platform == 'darwin':
                     return Action.OPEN_IN_FINDER
                 return Action.NONE
+            elif next_key == curses.KEY_LEFT:
+                # Alt+Left - back through directory history
+                self.active_panel.navigate_back()
+                self.command_line.set_path(str(self.active_panel.path))
+            elif next_key == curses.KEY_RIGHT:
+                # Alt+Right - forward through directory history
+                self.active_panel.navigate_forward()
+                self.command_line.set_path(str(self.active_panel.path))
             elif next_key != -1:
                 # Got a different key after Escape - push it back for processing
                 curses.ungetch(next_key)

--- a/tnc/panel.py
+++ b/tnc/panel.py
@@ -103,6 +103,8 @@ class Panel:
 
     # Maximum number of entries in navigation history
     _HISTORY_LIMIT = 50
+    # Maximum number of entries in the back/forward directory stacks
+    _BACK_FORWARD_LIMIT = 50
 
     def __init__(self, path: str, width: int = 40, height: int = 20) -> None:
         """Initialize the panel.
@@ -133,6 +135,10 @@ class Panel:
         # Navigation history: maps parent path -> child directory name
         # Used to remember position when navigating up via '..'
         self._navigation_history: dict[Path, str] = {}
+        # Back/forward stacks for Alt+Left / Alt+Right history navigation.
+        # Each entry is a previously visited Path; oldest evicted at limit.
+        self._back_stack: list[Path] = []
+        self._forward_stack: list[Path] = []
         # Cached directory sizes: maps full path -> size in bytes
         # Persists for the entire session (not cleared on directory change)
         self._dir_size_cache: dict[Path, int] = {}
@@ -634,17 +640,35 @@ class Panel:
         # It's a file - return path for editing
         return full_path
 
-    def change_directory(self, new_path: Path, external: bool = False) -> None:
+    def change_directory(
+        self,
+        new_path: Path,
+        external: bool = False,
+        *,
+        _from_history: bool = False,
+    ) -> None:
         """Change to a new directory.
 
         Args:
             new_path: The new directory path.
             external: If True, clear navigation history (for command-line nav).
+            _from_history: Internal flag set by navigate_back/navigate_forward
+                so the back/forward stacks aren't mutated by the history step
+                itself.
         """
         if external:
             self._navigation_history.clear()
 
-        self.path = new_path.resolve()
+        resolved = new_path.resolve()
+        # On a manual (non-history) directory change, record where we came from
+        # for Alt+Left and discard any pending forward history.
+        if not _from_history and resolved != self.path:
+            self._back_stack.append(self.path)
+            if len(self._back_stack) > self._BACK_FORWARD_LIMIT:
+                self._back_stack.pop(0)
+            self._forward_stack.clear()
+
+        self.path = resolved
         self.scroll_offset = 0
         self.selected.clear()
         # Note: _dir_size_cache is NOT cleared - it persists for the session
@@ -655,6 +679,36 @@ class Panel:
         restored_index = self._find_entry_index(remembered_child) if remembered_child else None
         self.cursor = restored_index if restored_index is not None else 0
         self._adjust_scroll()
+
+    def navigate_back(self) -> bool:
+        """Navigate to the previous directory in the back stack.
+
+        Returns:
+            True if a back step was taken, False if the back stack was empty.
+        """
+        if not self._back_stack:
+            return False
+        target = self._back_stack.pop()
+        self._forward_stack.append(self.path)
+        if len(self._forward_stack) > self._BACK_FORWARD_LIMIT:
+            self._forward_stack.pop(0)
+        self.change_directory(target, _from_history=True)
+        return True
+
+    def navigate_forward(self) -> bool:
+        """Navigate to the next directory in the forward stack.
+
+        Returns:
+            True if a forward step was taken, False if the forward stack was empty.
+        """
+        if not self._forward_stack:
+            return False
+        target = self._forward_stack.pop()
+        self._back_stack.append(self.path)
+        if len(self._back_stack) > self._BACK_FORWARD_LIMIT:
+            self._back_stack.pop(0)
+        self.change_directory(target, _from_history=True)
+        return True
 
     def toggle_selection(self) -> None:
         """Toggle selection of the current entry and advance cursor."""

--- a/tnc/panel.py
+++ b/tnc/panel.py
@@ -101,9 +101,8 @@ def render_panel_entries(
 class Panel:
     """A panel displaying directory contents."""
 
-    # Cap on the breadcrumb cache (parent path -> remembered child name).
+    # Maximum number of entries in navigation history
     _HISTORY_LIMIT = 50
-    # Independent cap on the Alt+Left/Right directory back & forward stacks.
     _BACK_FORWARD_LIMIT = 50
 
     def __init__(self, path: str, width: int = 40, height: int = 20) -> None:
@@ -135,8 +134,7 @@ class Panel:
         # Navigation history: maps parent path -> child directory name
         # Used to remember position when navigating up via '..'
         self._navigation_history: dict[Path, str] = {}
-        # Back/forward stacks for Alt+Left / Alt+Right history navigation.
-        # Each entry is a previously visited Path; oldest evicted at limit.
+        # Back/forward stacks for Alt+Left / Alt+Right history navigation
         self._back_stack: list[Path] = []
         self._forward_stack: list[Path] = []
         # Cached directory sizes: maps full path -> size in bytes
@@ -651,12 +649,10 @@ class Panel:
 
         Args:
             new_path: The new directory path.
-            external: If True, treat as a fresh-start jump: clear breadcrumb
-                cache and the Alt+Left/Right back/forward stacks (for
-                command-line nav or other external triggers).
-            _from_history: Internal flag set by navigate_back/navigate_forward
-                so the back/forward stacks aren't mutated by the history step
-                itself.
+            external: If True, clear navigation history and back/forward stacks
+                (for command-line nav or other external triggers).
+            _from_history: Internal flag for navigate_back/navigate_forward to
+                avoid mutating back/forward stacks during a history step.
         """
         if external:
             self._navigation_history.clear()
@@ -664,9 +660,6 @@ class Panel:
             self._forward_stack.clear()
 
         resolved = new_path.resolve()
-        # On a manual (non-history, non-external) directory change, record
-        # where we came from for Alt+Left and discard any pending forward
-        # history. External jumps wiped both stacks above and start fresh.
         if not _from_history and not external and resolved != self.path:
             self._back_stack.append(self.path)
             if len(self._back_stack) > self._BACK_FORWARD_LIMIT:
@@ -685,33 +678,26 @@ class Panel:
         self.cursor = restored_index if restored_index is not None else 0
         self._adjust_scroll()
 
-    def navigate_back(self) -> bool:
-        """Navigate to the previous directory in the back stack.
+    def _push_capped(self, stack: list[Path], path: Path) -> None:
+        stack.append(path)
+        if len(stack) > self._BACK_FORWARD_LIMIT:
+            stack.pop(0)
 
-        Returns:
-            True if a back step was taken, False if the back stack was empty.
-        """
+    def navigate_back(self) -> bool:
+        """Step to the previous directory; returns False if back stack is empty."""
         if not self._back_stack:
             return False
         target = self._back_stack.pop()
-        self._forward_stack.append(self.path)
-        if len(self._forward_stack) > self._BACK_FORWARD_LIMIT:
-            self._forward_stack.pop(0)
+        self._push_capped(self._forward_stack, self.path)
         self.change_directory(target, _from_history=True)
         return True
 
     def navigate_forward(self) -> bool:
-        """Navigate to the next directory in the forward stack.
-
-        Returns:
-            True if a forward step was taken, False if the forward stack was empty.
-        """
+        """Step to the next directory; returns False if forward stack is empty."""
         if not self._forward_stack:
             return False
         target = self._forward_stack.pop()
-        self._back_stack.append(self.path)
-        if len(self._back_stack) > self._BACK_FORWARD_LIMIT:
-            self._back_stack.pop(0)
+        self._push_capped(self._back_stack, self.path)
         self.change_directory(target, _from_history=True)
         return True
 

--- a/tnc/panel.py
+++ b/tnc/panel.py
@@ -101,9 +101,9 @@ def render_panel_entries(
 class Panel:
     """A panel displaying directory contents."""
 
-    # Maximum number of entries in navigation history
+    # Cap on the breadcrumb cache (parent path -> remembered child name).
     _HISTORY_LIMIT = 50
-    # Maximum number of entries in the back/forward directory stacks
+    # Independent cap on the Alt+Left/Right directory back & forward stacks.
     _BACK_FORWARD_LIMIT = 50
 
     def __init__(self, path: str, width: int = 40, height: int = 20) -> None:
@@ -651,18 +651,23 @@ class Panel:
 
         Args:
             new_path: The new directory path.
-            external: If True, clear navigation history (for command-line nav).
+            external: If True, treat as a fresh-start jump: clear breadcrumb
+                cache and the Alt+Left/Right back/forward stacks (for
+                command-line nav or other external triggers).
             _from_history: Internal flag set by navigate_back/navigate_forward
                 so the back/forward stacks aren't mutated by the history step
                 itself.
         """
         if external:
             self._navigation_history.clear()
+            self._back_stack.clear()
+            self._forward_stack.clear()
 
         resolved = new_path.resolve()
-        # On a manual (non-history) directory change, record where we came from
-        # for Alt+Left and discard any pending forward history.
-        if not _from_history and resolved != self.path:
+        # On a manual (non-history, non-external) directory change, record
+        # where we came from for Alt+Left and discard any pending forward
+        # history. External jumps wiped both stacks above and start fresh.
+        if not _from_history and not external and resolved != self.path:
             self._back_stack.append(self.path)
             if len(self._back_stack) > self._BACK_FORWARD_LIMIT:
                 self._back_stack.pop(0)


### PR DESCRIPTION
## Summary

- Adds `Alt+Left` (back) and `Alt+Right` (forward) directory-history navigation per issue #19.
- Each `Panel` keeps its own 50-entry `_back_stack` / `_forward_stack`; manual nav (Enter or `..`) pushes to back and clears forward; `change_directory(external=True)` resets both for a clean slate.
- App routes `Esc + KEY_LEFT` / `Esc + KEY_RIGHT` to the active panel (mirroring the existing Alt+Enter / Alt+O detection) and re-syncs the command-line prompt.

## Related Issue

Closes #19.

## Changes Made

- `tnc/panel.py`: new `_BACK_FORWARD_LIMIT = 50`, `_back_stack` / `_forward_stack` instance lists, `_push_capped` helper, `navigate_back()` / `navigate_forward()` methods. `change_directory(...)` gains a keyword-only `_from_history` flag so history steps don't mutate the stacks; `external=True` now also wipes the stacks for API consistency.
- `tnc/app.py`: two `elif` branches inside the existing `Esc`-prefix Alt sequence handler in `handle_key`, calling `active_panel.navigate_back()` / `navigate_forward()` and updating `command_line.set_path(...)`.
- `tests/test_back_forward_navigation.py` (new): 22 behavioral tests covering empty stacks, manual-nav push/clear, round-trip A→B→C → back×2 → forward×2, no-op same-path, FIFO eviction at the limit, per-panel independence, `..` push, missing-target both directions, external-clear, plain-Left regression guard, end-to-end Alt+Left, and panel-switch preservation.
- `CLAUDE.md`, `README.md`: keybinding tables updated with `Alt+Left` / `Alt+Right`.

## Testing Done

- [x] Unit tests pass (`python3 -m unittest tests.test_back_forward_navigation` — 22/22)
- [x] Full suite green vs. baseline (`python3 -m unittest discover -s tests` — 1109 tests, same 5 pre-existing failures unrelated to this PR: 3 mouse, 1 edit-textedit, 1 create_file permission)
- [x] Code review (pr-review-toolkit:code-reviewer) — no HIGH; one MEDIUM addressed (M1: external=True now resets stacks)
- [x] Silent-failure-hunter — no HIGH/MEDIUM; existing `Panel.error_message` surfacing covers missing-target case
- [x] Code simplifier pass — extracted `_push_capped` helper, tightened comments
- [x] Test-coverage analyzer — added 2 follow-up tests (end-to-end Alt+Left, panel-switch independence)
- [ ] Manual smoke testing: not run in this PR (no terminal access in CI sandbox); reviewers should confirm Alt+Left / Alt+Right behavior in their terminal.

## Out of Scope (locked in via Phase 1 issue comment)

- Cursor / scroll-position restoration on Alt+Left/Right (lands at row 0; future enhancement)
- Command-line `cd <path>` panel-aware behavior
- History dropdown UI
- Persisting back/forward across app restarts

## Breaking Changes

None. New keybindings only; plain Left/Right continue to drive the command-line cursor.

## Checklist

- [x] Code follows project conventions (stdlib-only, simple, minimal docstrings)
- [x] Tests added (TDD: every test written before its implementation; full red/green observed locally)
- [x] Documentation updated (CLAUDE.md + README.md key-binding tables)
- [x] No secrets committed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
