### PR TITLE
fix(file_ops): refuse copy/move of directory into its own subdirectory

### DIFF
--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -244,6 +244,43 @@ class TestCopyErrorHandling(unittest.TestCase):
                 result = copy_files([], source_dir, dest_dir)
                 self.assertTrue(result.success)
 
+    def test_copy_directory_into_own_subdirectory_refused(self):
+        """Copying a directory into its own subdirectory should be refused, not recurse forever."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            sub = source_dir / 'sub'
+            sub.mkdir()
+            (sub / 'file.txt').write_text('hello')
+
+            result = copy_files(['sub'], str(source_dir), str(sub))
+
+            self.assertFalse(result.success)
+            self.assertTrue(
+                'into itself' in result.error.lower() or 'subdirector' in result.error.lower(),
+                f'Expected refusal message, got: {result.error!r}'
+            )
+            self.assertFalse((sub / 'sub').exists(), 'No recursive copy should have occurred')
+
+    def test_move_directory_into_own_subdirectory_refused(self):
+        """Moving a directory into its own subdirectory should be refused."""
+        from tnc.file_ops import move_files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = Path(tmpdir)
+            sub = source_dir / 'sub'
+            sub.mkdir()
+            (sub / 'file.txt').write_text('hello')
+
+            result = move_files(['sub'], str(source_dir), str(sub))
+
+            self.assertFalse(result.success)
+            self.assertTrue(
+                'into itself' in result.error.lower() or 'subdirector' in result.error.lower(),
+                f'Expected refusal message, got: {result.error!r}'
+            )
+            # Source must still exist - move was refused before any change
+            self.assertTrue(sub.exists())
+            self.assertTrue((sub / 'file.txt').exists())
+
 
 class TestCopyResult(unittest.TestCase):
     """Test CopyResult dataclass."""

--- a/tnc/file_ops.py
+++ b/tnc/file_ops.py
@@ -389,6 +389,24 @@ def chown_files(
     return ChownResult(success=True, changed_files=changed)
 
 
+def _is_dest_inside_source(source_path: Path, dest_path: Path) -> bool:
+    """True when source is a directory and dest_path equals it or lies within it.
+
+    Prevents copy/move from recursing forever when the user picks a destination
+    that happens to be a child of the source (e.g. moving /a into /a/sub).
+    """
+    if not source_path.is_dir() or source_path.is_symlink():
+        return False
+    try:
+        resolved_source = source_path.resolve()
+        resolved_dest = dest_path.resolve()
+    except OSError:
+        return False
+    if resolved_dest == resolved_source:
+        return True
+    return resolved_source in resolved_dest.parents
+
+
 def _copy_item(source_path: Path, dest_path: Path) -> None:
     """Copy a single file or directory with proper handling for different types.
 
@@ -456,6 +474,11 @@ def _process_file_operation(
         try:
             if not source_path.exists() and not source_path.is_symlink():
                 errors.append(f'{filename}: File not found')
+                continue
+
+            if _is_dest_inside_source(source_path, dest_path):
+                verb = 'copy' if result_attr == 'copied_files' else 'move'
+                errors.append(f'{filename}: Cannot {verb} directory into itself or a subdirectory')
                 continue
 
             operation(source_path, dest_path)
@@ -748,6 +771,12 @@ def _process_files_with_overwrite(
         try:
             if not source_path.exists() and not source_path.is_symlink():
                 errors.append(f'{filename}: File not found')
+                continue
+
+            if _is_dest_inside_source(source_path, dest_path):
+                errors.append(
+                    f'{filename}: Cannot {operation_name} directory into itself or a subdirectory'
+                )
                 continue
 
             # Check for conflict


### PR DESCRIPTION
## Summary
- Refuses copy/move when destination equals source or is a subdirectory of source
- Prevents the recursive `shutil.copytree` blow-up that filled the filesystem
- Adds tests reproducing the original symptom

Closes #21

## Changes
- `tnc/file_ops.py`: new `_is_dest_inside_source` helper; called from both `_process_file_operation` and `_process_files_with_overwrite` before any disk write
- `tests/test_file_ops.py`: regression tests for copy and move

## Test plan
- [x] `python3 -m unittest tests.test_file_ops` — all 31 pass
- [x] `python3 -m unittest discover -s tests` — no new failures (4 failures + 1 error pre-existed on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)