### PR TITLE
fix(file_ops): rollback partial overwrite when copy/move fails

### DIFF
--- a/tests/test_overwrite.py
+++ b/tests/test_overwrite.py
@@ -341,5 +341,70 @@ class TestOverwriteOlder(unittest.TestCase):
                 self.assertEqual(len(result.skipped_files), 1)
 
 
+class TestOverwriteRollback(unittest.TestCase):
+    """Test that a failed overwrite leaves the original destination intact."""
+
+    def test_failed_copy_preserves_original_destination(self):
+        """When copy fails after the user confirmed overwrite, the destination must not be lost."""
+        from unittest import mock
+        from tnc import file_ops
+
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                Path(source_dir, 'file.txt').write_text('source content')
+                dest_file = Path(dest_dir, 'file.txt')
+                dest_file.write_text('precious dest content')
+                handler = MockOverwriteHandler([OverwriteChoice.YES])
+
+                with mock.patch.object(
+                    file_ops, '_copy_item',
+                    side_effect=OSError('disk simulated full')
+                ):
+                    result = copy_files_with_overwrite(
+                        ['file.txt'], source_dir, dest_dir, handler
+                    )
+
+                self.assertFalse(result.success)
+                # The original destination must still be there with its original content
+                self.assertTrue(dest_file.exists())
+                self.assertEqual(dest_file.read_text(), 'precious dest content')
+                # No leftover sidecar files
+                leftovers = [p.name for p in Path(dest_dir).iterdir()]
+                self.assertEqual(leftovers, ['file.txt'])
+
+    def test_failed_directory_overwrite_preserves_original(self):
+        """A failed directory overwrite should leave the original tree intact."""
+        from unittest import mock
+        from tnc import file_ops
+
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                src_tree = Path(source_dir, 'data')
+                src_tree.mkdir()
+                (src_tree / 'a.txt').write_text('new')
+
+                dst_tree = Path(dest_dir, 'data')
+                dst_tree.mkdir()
+                (dst_tree / 'b.txt').write_text('original-b')
+                (dst_tree / 'c.txt').write_text('original-c')
+
+                handler = MockOverwriteHandler([OverwriteChoice.YES])
+
+                with mock.patch.object(
+                    file_ops, '_copy_item',
+                    side_effect=OSError('simulated copy failure')
+                ):
+                    result = copy_files_with_overwrite(
+                        ['data'], source_dir, dest_dir, handler
+                    )
+
+                self.assertFalse(result.success)
+                self.assertTrue(dst_tree.is_dir())
+                self.assertEqual((dst_tree / 'b.txt').read_text(), 'original-b')
+                self.assertEqual((dst_tree / 'c.txt').read_text(), 'original-c')
+                leftovers = sorted(p.name for p in Path(dest_dir).iterdir())
+                self.assertEqual(leftovers, ['data'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tnc/file_ops.py
+++ b/tnc/file_ops.py
@@ -724,6 +724,55 @@ def delete_files(filenames: list[str], parent_dir: str | Path) -> DeleteResult:
     return DeleteResult(success=True, deleted_files=deleted)
 
 
+def _move_aside(dest_path: Path) -> Path | None:
+    """Rename dest_path to a sidecar so it can be restored on failure.
+
+    Returns the sidecar path, or None if dest_path did not exist.
+    """
+    if not (dest_path.exists() or dest_path.is_symlink()):
+        return None
+    for attempt in range(100):
+        sidecar = dest_path.with_name(f'{dest_path.name}.tnc-replace-{os.getpid()}-{attempt}')
+        if sidecar.exists() or sidecar.is_symlink():
+            continue
+        os.rename(dest_path, sidecar)
+        return sidecar
+    raise OSError('could not allocate sidecar name for atomic overwrite')
+
+
+def _rollback_sidecar(dest_path: Path, sidecar: Path | None) -> None:
+    """Restore the sidecar back to dest_path after a failed operation."""
+    if sidecar is None:
+        return
+    # Remove any partial result that the failed operation may have left behind.
+    if dest_path.exists() or dest_path.is_symlink():
+        if dest_path.is_dir() and not dest_path.is_symlink():
+            shutil.rmtree(dest_path, ignore_errors=True)
+        else:
+            try:
+                dest_path.unlink()
+            except OSError:
+                pass
+    try:
+        os.rename(sidecar, dest_path)
+    except OSError:
+        # Last resort: leave the sidecar in place rather than losing data
+        pass
+
+
+def _drop_sidecar(sidecar: Path | None) -> None:
+    """Remove a successfully replaced sidecar."""
+    if sidecar is None:
+        return
+    if sidecar.is_dir() and not sidecar.is_symlink():
+        shutil.rmtree(sidecar, ignore_errors=True)
+    else:
+        try:
+            sidecar.unlink()
+        except OSError:
+            pass
+
+
 def _process_files_with_overwrite(
     filenames: list[str],
     source_dir: str | Path,
@@ -813,11 +862,19 @@ def _process_files_with_overwrite(
                     skipped.append(filename)
                     continue
 
-                # Remove existing file/dir before operation
-                if dest_path.is_dir() and not dest_path.is_symlink():
-                    shutil.rmtree(dest_path)
+                # Rename existing dest aside before the operation. If the op
+                # then fails the sidecar is rolled back, so the user is never
+                # left with a half-deleted destination and no source copy.
+                sidecar = _move_aside(dest_path)
+                try:
+                    operation(source_path, dest_path)
+                except BaseException:
+                    _rollback_sidecar(dest_path, sidecar)
+                    raise
                 else:
-                    dest_path.unlink()
+                    _drop_sidecar(sidecar)
+                processed.append(filename)
+                continue
 
             operation(source_path, dest_path)
             processed.append(filename)


### PR DESCRIPTION
## Summary
- Renames the destination to a sidecar before running copy/move
- Restores the sidecar on failure so the user never loses both old and new
- Drops the sidecar after a successful operation

Closes #22

## Test plan
- [x] `python3 -m unittest tests.test_overwrite` — all 14 pass, including new rollback tests
- [x] `python3 -m unittest discover -s tests` — no new failures vs. main

🤖 Generated with [Claude Code](https://claude.com/claude-code)