### PR TITLE
fix(file_ops): refuse to overwrite mismatched file/directory types

### DIFF
--- a/tests/test_overwrite.py
+++ b/tests/test_overwrite.py
@@ -341,6 +341,70 @@ class TestOverwriteOlder(unittest.TestCase):
                 self.assertEqual(len(result.skipped_files), 1)
 
 
+class TestOverwriteTypeMismatch(unittest.TestCase):
+    """Refuse to overwrite when source and destination types differ."""
+
+    def test_file_over_directory_refused(self):
+        """Copying a file onto a directory of the same name must not delete the directory."""
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                Path(source_dir, 'notes').write_text('a single file')
+                dst_dir = Path(dest_dir, 'notes')
+                dst_dir.mkdir()
+                (dst_dir / 'inner.txt').write_text('precious')
+                handler = MockOverwriteHandler([OverwriteChoice.YES])
+
+                result = copy_files_with_overwrite(
+                    ['notes'], source_dir, dest_dir, handler
+                )
+
+                self.assertFalse(result.success)
+                self.assertIn('directory', result.error.lower())
+                self.assertEqual(handler.prompt_count, 0,
+                    'Should not prompt — refusal must precede prompting')
+                self.assertTrue(dst_dir.is_dir())
+                self.assertEqual((dst_dir / 'inner.txt').read_text(), 'precious')
+
+    def test_directory_over_file_refused(self):
+        """Copying a directory onto a file of the same name must not delete the file."""
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                src_dir = Path(source_dir, 'notes')
+                src_dir.mkdir()
+                (src_dir / 'a.txt').write_text('source')
+                dst_file = Path(dest_dir, 'notes')
+                dst_file.write_text('precious file content')
+                handler = MockOverwriteHandler([OverwriteChoice.YES])
+
+                result = copy_files_with_overwrite(
+                    ['notes'], source_dir, dest_dir, handler
+                )
+
+                self.assertFalse(result.success)
+                self.assertIn('directory', result.error.lower())
+                self.assertEqual(handler.prompt_count, 0)
+                self.assertTrue(dst_file.is_file())
+                self.assertEqual(dst_file.read_text(), 'precious file content')
+
+    def test_move_file_over_directory_refused(self):
+        """Move must also refuse mismatched types."""
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                Path(source_dir, 'notes').write_text('a single file')
+                dst_dir = Path(dest_dir, 'notes')
+                dst_dir.mkdir()
+                (dst_dir / 'inner.txt').write_text('precious')
+                handler = MockOverwriteHandler([OverwriteChoice.YES])
+
+                result = move_files_with_overwrite(
+                    ['notes'], source_dir, dest_dir, handler
+                )
+
+                self.assertFalse(result.success)
+                self.assertTrue(dst_dir.is_dir())
+                self.assertEqual((dst_dir / 'inner.txt').read_text(), 'precious')
+
+
 class TestOverwriteRollback(unittest.TestCase):
     """Test that a failed overwrite leaves the original destination intact."""
 

--- a/tnc/file_ops.py
+++ b/tnc/file_ops.py
@@ -724,6 +724,34 @@ def delete_files(filenames: list[str], parent_dir: str | Path) -> DeleteResult:
     return DeleteResult(success=True, deleted_files=deleted)
 
 
+def _type_mismatch_error(
+    source_path: Path, dest_path: Path, operation_name: str
+) -> str | None:
+    """Return an error string when source and destination have incompatible types.
+
+    Symlinks are treated as their own kind so that overwriting a symlink with
+    a real file/directory still goes through the normal overwrite prompt.
+    """
+    src_kind = _path_kind(source_path)
+    dst_kind = _path_kind(dest_path)
+    if src_kind == dst_kind:
+        return None
+    if 'symlink' in (src_kind, dst_kind):
+        return None
+    return (
+        f'Refusing to {operation_name} {src_kind} over existing {dst_kind} '
+        f'(delete destination first if intentional)'
+    )
+
+
+def _path_kind(path: Path) -> str:
+    if path.is_symlink():
+        return 'symlink'
+    if path.is_dir():
+        return 'directory'
+    return 'file'
+
+
 def _move_aside(dest_path: Path) -> Path | None:
     """Rename dest_path to a sidecar so it can be restored on failure.
 
@@ -830,6 +858,14 @@ def _process_files_with_overwrite(
 
             # Check for conflict
             if dest_path.exists() or dest_path.is_symlink():
+                # Refuse mismatched types: file vs. directory. The overwrite
+                # dialog only describes file metadata, so a "Yes" there would
+                # silently delete a whole directory tree.
+                mismatch = _type_mismatch_error(source_path, dest_path, operation_name)
+                if mismatch is not None:
+                    errors.append(f'{filename}: {mismatch}')
+                    continue
+
                 source_stat = source_path.stat()
                 dest_stat = dest_path.stat()
                 source_size = source_stat.st_size if source_path.is_file() else 0


### PR DESCRIPTION
## Summary
- Refuses to copy/move a file onto an existing directory (and vice versa)
- Surfaces a clear per-file error rather than silently rmtree-ing the destination
- Symlinks still go through the normal overwrite prompt

Closes #23

## Test plan
- [x] `python3 -m unittest tests.test_overwrite` — all 17 pass (3 new mismatch tests)
- [x] `python3 -m unittest discover -s tests` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)