### PR TITLE
fix(app): use safe_addstr in _measure_dir_size

### DIFF
--- a/tests/test_dir_size.py
+++ b/tests/test_dir_size.py
@@ -1,9 +1,11 @@
 """Tests for directory size calculation functionality."""
 
+import curses
 import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tnc.file_ops import calculate_dir_size
 
@@ -166,6 +168,43 @@ class TestCalculateDirSize(unittest.TestCase):
         size = calculate_dir_size(test_dir)
 
         self.assertIsInstance(size, int)
+
+
+class TestMeasureDirSizeNarrowTerminal(unittest.TestCase):
+    """Alt+F3 must not crash on narrow terminals (issue #25)."""
+
+    def test_calculating_message_does_not_crash_on_narrow_terminal(self) -> None:
+        """Status line write must be wrapped — narrow terminals make raw addstr raise."""
+        from tests.helpers import create_mock_stdscr, find_entry_index
+        from tnc.app import App
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sub = Path(tmpdir) / 'sub'
+            sub.mkdir()
+            (sub / 'file.txt').write_text('content')
+
+            stdscr = create_mock_stdscr(rows=24, cols=20)
+
+            def narrow_addstr(*args, **kwargs):
+                # Mimic ncurses behavior: writing through to the bottom-right
+                # corner raises because the cursor advance would scroll.
+                if len(args) >= 3 and isinstance(args[2], str):
+                    text = args[2]
+                    x = args[1] if isinstance(args[1], int) else 0
+                    if x + len(text) >= 20:
+                        raise curses.error('addwstr() returned ERR')
+
+            stdscr.addstr = mock.Mock(side_effect=narrow_addstr)
+
+            with mock.patch('curses.has_colors', return_value=False), \
+                 mock.patch('curses.curs_set'), \
+                 mock.patch('curses.mousemask'), \
+                 mock.patch('os.getcwd', return_value=tmpdir):
+                app = App(stdscr)
+                app.setup()
+                app.active_panel.cursor = find_entry_index(app.active_panel, 'sub')
+                # Pre-fix this raised curses.error and crashed the app loop.
+                app._measure_dir_size()
 
 
 if __name__ == '__main__':

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -35,6 +35,7 @@ from tnc.function_bar import FunctionBar
 from tnc.menu import MenuBar
 from tnc.panel import Panel
 from tnc.status_bar import StatusBar
+from tnc.utils import safe_addstr
 
 
 class Action(Enum):
@@ -1522,11 +1523,10 @@ class App:
         if not full_path.is_dir():
             return
 
-        # Show calculating message
-        self.stdscr.addstr(
-            self.stdscr.getmaxyx()[0] - 2, 0,
-            'Calculating...'.ljust(self.stdscr.getmaxyx()[1])
-        )
+        # Show calculating message — use safe_addstr because narrow terminals
+        # would otherwise raise curses.error and crash the app loop.
+        rows, cols = self.stdscr.getmaxyx()
+        safe_addstr(self.stdscr, rows - 2, 0, 'Calculating...'.ljust(cols))
         self.stdscr.refresh()
 
         # Calculate size and cache it


### PR DESCRIPTION
## Summary
- Replaces direct `stdscr.addstr` with `safe_addstr` in the Alt+F3 handler
- Prevents `curses.error` on narrow terminals from crashing the app

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)