### PR TITLE
fix(config): handle Config.save OSError without crashing UI

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,6 +227,42 @@ class TestMouseSwapConfig(unittest.TestCase):
             self.assertIn('mouse_swap = no', content)
 
 
+class TestConfigSaveErrorReporting(unittest.TestCase):
+    """Config.save should report failure rather than crash the caller (issue #26)."""
+
+    def test_save_returns_true_on_success(self):
+        """Successful writes return True."""
+        from tnc.config import Config
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / 'config'
+            config = Config()
+            self.assertTrue(config.save(str(config_path)))
+
+    def test_save_returns_false_when_path_unwritable(self):
+        """When the open() raises OSError, save returns False rather than propagating."""
+        from unittest import mock
+        from tnc.config import Config
+
+        config = Config()
+        with mock.patch('builtins.open', side_effect=PermissionError('readonly')):
+            result = config.save('/some/path/config')
+
+        self.assertFalse(result)
+
+    def test_save_returns_false_when_disk_full(self):
+        """OSError during write must be swallowed and surface as a False return."""
+        from unittest import mock
+        from tnc.config import Config
+
+        config = Config()
+        m = mock.mock_open()
+        m.return_value.write.side_effect = OSError('disk full')
+        with mock.patch('builtins.open', m):
+            result = config.save('/some/path/config')
+
+        self.assertFalse(result)
+
+
 class TestConfigPreserveUnknown(unittest.TestCase):
     """Test preserving unknown config keys."""
 

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -872,13 +872,21 @@ class App:
 
         return dialog.show(self.stdscr)
 
+    def _save_config_or_warn(self) -> None:
+        """Persist config; show a non-fatal dialog if the write fails."""
+        if not self.config.save():
+            show_error_dialog(
+                self.stdscr, 'Error',
+                f'Could not save config to {self.config.path}'
+            )
+
     def _prompt_pager_setup(self) -> None:
         """Prompt user to select a pager."""
         options = Config.get_available_pagers()
         selected = self._prompt_tool_setup('pager', options)
         if selected:
             self.config.pager = selected
-            self.config.save()
+            self._save_config_or_warn()
 
     def _prompt_editor_setup(self) -> None:
         """Prompt user to select an editor."""
@@ -886,7 +894,7 @@ class App:
         selected = self._prompt_tool_setup('editor', options)
         if selected:
             self.config.editor = selected
-            self.config.save()
+            self._save_config_or_warn()
 
     def _toggle_classic_colors(self) -> None:
         """Toggle between classic mc-style blue and modern transparent theme."""
@@ -895,7 +903,7 @@ class App:
         set_classic_theme(new_value)
         # Save to config
         self.config.classic_colors = new_value
-        self.config.save()
+        self._save_config_or_warn()
 
     def _enable_mouse(self) -> bool:
         """Enable mouse event capture.
@@ -937,7 +945,7 @@ class App:
         else:
             self._enable_mouse()
             self.config.mouse_enabled = True
-        self.config.save()
+        self._save_config_or_warn()
 
     def _toggle_menu_dropdown(self) -> None:
         """Toggle menu dropdown open/closed."""
@@ -948,7 +956,7 @@ class App:
     def _toggle_mouse_swap(self) -> None:
         """Toggle mouse button swap (for left-handed users) and save to config."""
         self.config.mouse_swap = not self.config.mouse_swap
-        self.config.save()
+        self._save_config_or_warn()
 
     def _translate_button_state(self, button_state: int) -> int:
         """Translate mouse button state based on swap setting.

--- a/tnc/config.py
+++ b/tnc/config.py
@@ -83,28 +83,29 @@ class Config:
 
         return config
 
-    def save(self, path: str | None = None) -> None:
+    def save(self, path: str | None = None) -> bool:
         """Save config to a file.
 
-        Args:
-            path: Path to config file. If None, uses the stored path.
+        Returns True on success, False if the write fails (disk full,
+        read-only filesystem, permission denied). Callers must check the
+        return value rather than letting an OSError tear down the UI.
         """
         save_path = path if path is not None else self.path
-        Path(save_path).parent.mkdir(parents=True, exist_ok=True)
-
-        with open(save_path, 'w') as f:
-            if self.editor is not None:
-                f.write(f'editor = {self.editor}\n')
-            if self.pager is not None:
-                f.write(f'pager = {self.pager}\n')
-            # Always write classic_colors setting
-            f.write(f'classic_colors = {"yes" if self.classic_colors else "no"}\n')
-            # Always write mouse_enabled setting
-            f.write(f'mouse_enabled = {"yes" if self.mouse_enabled else "no"}\n')
-            # Always write mouse_swap setting
-            f.write(f'mouse_swap = {"yes" if self.mouse_swap else "no"}\n')
-            for key, value in self._unknown_keys.items():
-                f.write(f'{key} = {value}\n')
+        try:
+            Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(save_path, 'w') as f:
+                if self.editor is not None:
+                    f.write(f'editor = {self.editor}\n')
+                if self.pager is not None:
+                    f.write(f'pager = {self.pager}\n')
+                f.write(f'classic_colors = {"yes" if self.classic_colors else "no"}\n')
+                f.write(f'mouse_enabled = {"yes" if self.mouse_enabled else "no"}\n')
+                f.write(f'mouse_swap = {"yes" if self.mouse_swap else "no"}\n')
+                for key, value in self._unknown_keys.items():
+                    f.write(f'{key} = {value}\n')
+        except OSError:
+            return False
+        return True
 
     def needs_editor_setup(self) -> bool:
         """Check if editor setup is needed.


### PR DESCRIPTION
## Summary
- `Config.save` now returns bool — True on success, False on OSError
- New `App._save_config_or_warn` shows a non-fatal dialog rather than letting curses tear down

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)