### PR TITLE
fix(file_ops): carry per-file errors as a list, not join/split round-trip

### DIFF
--- a/tests/test_file_ops.py
+++ b/tests/test_file_ops.py
@@ -205,6 +205,29 @@ class TestCopySymlink(unittest.TestCase):
 class TestCopyErrorHandling(unittest.TestCase):
     """Test error handling during copy."""
 
+    def test_errors_list_preserves_filenames_with_semicolon(self):
+        """Per-file errors with '; ' in the path must not be split (issue #33)."""
+        from tnc.file_ops import copy_files
+
+        with tempfile.TemporaryDirectory() as source_dir:
+            with tempfile.TemporaryDirectory() as dest_dir:
+                # Create two files; one has '; ' in its name
+                weird = 'a; b.txt'
+                Path(source_dir, weird).write_text('one')
+                Path(source_dir, 'normal.txt').write_text('two')
+                # Mark dest as read-only so copies fail
+                os.chmod(dest_dir, 0o500)
+                try:
+                    result = copy_files([weird, 'normal.txt'], source_dir, dest_dir)
+                finally:
+                    os.chmod(dest_dir, 0o755)
+
+                self.assertFalse(result.success)
+                # The list-based errors field must preserve filenames intact
+                self.assertEqual(len(result.errors), 2)
+                self.assertTrue(any(weird in e for e in result.errors),
+                    f'Expected weird filename in errors list, got: {result.errors!r}')
+
     def test_copy_to_same_directory_fails(self):
         """Copy to same directory should fail gracefully."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -696,8 +696,11 @@ class App:
 
         # Show summary (with errors if any)
         self.draw()
-        # Split error string back into list for display
-        error_list = result.error.split('; ') if result.error else None
+        # Use the structured errors list directly — splitting result.error
+        # on '; ' was unsafe for filenames containing that sequence.
+        error_list = list(result.errors) if result.errors else (
+            [result.error] if result.error else None
+        )
         show_summary(
             self.stdscr, operation_name.lower(),
             **{summary_kwarg: len(processed_files)},

--- a/tnc/file_ops.py
+++ b/tnc/file_ops.py
@@ -174,6 +174,7 @@ class CopyResult:
     copied_files: list[str] = field(default_factory=list)
     skipped_files: list[str] = field(default_factory=list)
     cancelled: bool = False
+    errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -185,6 +186,7 @@ class MoveResult:
     moved_files: list[str] = field(default_factory=list)
     skipped_files: list[str] = field(default_factory=list)
     cancelled: bool = False
+    errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -212,6 +214,7 @@ class DeleteResult:
     success: bool
     error: str = ''
     deleted_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -230,6 +233,7 @@ class ChmodResult:
     success: bool
     error: str = ''
     changed_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -239,6 +243,7 @@ class ChownResult:
     success: bool
     error: str = ''
     changed_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
 
 
 def chmod_files(
@@ -279,7 +284,8 @@ def chmod_files(
         return ChmodResult(
             success=False,
             error='; '.join(errors),
-            changed_files=changed
+            changed_files=changed,
+            errors=list(errors),
         )
 
     return ChmodResult(success=True, changed_files=changed)
@@ -352,7 +358,8 @@ def chmod_recursive(
         return ChmodResult(
             success=False,
             error='; '.join(errors),
-            changed_files=changed
+            changed_files=changed,
+            errors=list(errors),
         )
 
     return ChmodResult(success=True, changed_files=changed)
@@ -398,7 +405,8 @@ def chown_files(
         return ChownResult(
             success=False,
             error='; '.join(errors),
-            changed_files=changed
+            changed_files=changed,
+            errors=list(errors),
         )
 
     return ChownResult(success=True, changed_files=changed)
@@ -508,6 +516,7 @@ def _process_file_operation(
         return result_class(
             success=False,
             error='; '.join(errors),
+            errors=list(errors),
             **{result_attr: processed}
         )
 
@@ -733,7 +742,8 @@ def delete_files(filenames: list[str], parent_dir: str | Path) -> DeleteResult:
         return DeleteResult(
             success=False,
             error='; '.join(errors),
-            deleted_files=deleted
+            deleted_files=deleted,
+            errors=list(errors),
         )
 
     return DeleteResult(success=True, deleted_files=deleted)
@@ -950,6 +960,7 @@ def _process_files_with_overwrite(
         return result_class(
             success=False,
             error='; '.join(errors),
+            errors=list(errors),
             skipped_files=skipped,
             **{result_attr: processed}
         )


### PR DESCRIPTION
Closes #33