### PR TITLE
fix(utils): wrap format_mtime against OverflowError/OSError/ValueError

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -267,5 +267,30 @@ class TestSafeAddstr(unittest.TestCase):
         win.addstr.assert_called_once_with(0, 0, '日本語テスト', 0)
 
 
+class TestFormatMtimeOverflow(unittest.TestCase):
+    """format_mtime must not crash on absurd timestamps (issue #39)."""
+
+    def test_overflow_returns_placeholder(self):
+        """Timestamps too large for the C library must return a placeholder, not crash."""
+        from tnc.utils import format_mtime
+        result = format_mtime(10**18)
+        self.assertEqual(len(result), 12)
+
+    def test_negative_extreme_returns_placeholder(self):
+        """Heavily negative timestamps must also be handled."""
+        from tnc.utils import format_mtime
+        result = format_mtime(-10**18)
+        self.assertEqual(len(result), 12)
+
+    def test_normal_timestamp_returns_formatted(self):
+        """A normal timestamp still returns the standard format."""
+        import time
+        from tnc.utils import format_mtime
+        now = time.time()
+        result = format_mtime(now)
+        self.assertEqual(len(result), 12)
+        self.assertNotIn('?', result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tnc/utils.py
+++ b/tnc/utils.py
@@ -115,7 +115,13 @@ def format_mtime(timestamp: float) -> str:
     # 6-month threshold matches ls -l behavior
     six_months_seconds = 180 * 24 * 60 * 60
 
-    local_time = time.localtime(timestamp)
+    try:
+        local_time = time.localtime(timestamp)
+    except (OverflowError, OSError, ValueError):
+        # Corrupt or absurd mtime (pre-1970, year > 9999) — render a
+        # placeholder of the same width as a normal timestamp so the
+        # panel doesn't shift columns.
+        return '????????????'  # 12 chars
     age = now - timestamp
 
     # Recent file: "MMM DD HH:MM", Old/future file: "MMM DD  YYYY"


### PR DESCRIPTION
Closes #39