### PR TITLE
fix(panel): invalidate dir-size cache when directory mtime advances (#46)

### DIFF
--- a/tests/test_dir_size.py
+++ b/tests/test_dir_size.py
@@ -207,5 +207,78 @@ class TestMeasureDirSizeNarrowTerminal(unittest.TestCase):
                 app._measure_dir_size()
 
 
+class TestDirSizeCacheInvalidation(unittest.TestCase):
+    """Issue #46: dir-size cache must invalidate when the measured
+    directory's mtime advances, otherwise F5/F6/F8 against the dir
+    leave stale numbers on screen indefinitely."""
+
+    def setUp(self) -> None:
+        from tnc.panel import Panel
+        self._panel_cls = Panel
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.measured = self.root / 'measured'
+        self.measured.mkdir()
+        (self.measured / 'a.txt').write_text('hello')  # 5 bytes
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _make_panel(self):
+        return self._panel_cls(str(self.root), width=80, height=20)
+
+    def _bump_mtime(self, path: Path) -> None:
+        """Force mtime to advance past the cached value, regardless of
+        filesystem timestamp resolution. Tests that rely on a real op
+        bumping mtime can be flaky on coarse-resolution filesystems
+        (HFS+, some network mounts), so we set it explicitly."""
+        st = path.stat()
+        os.utime(path, (st.st_atime, st.st_mtime + 1.0))
+
+    def test_get_cached_returns_size_when_mtime_unchanged(self) -> None:
+        panel = self._make_panel()
+        size = panel.measure_dir_size('measured')
+        self.assertGreaterEqual(size, 0)
+        # Same mtime — cache hit.
+        self.assertEqual(panel.get_cached_dir_size('measured'), size)
+
+    def test_get_cached_returns_none_after_file_added_to_dir(self) -> None:
+        """Regression test for issue #46: F5 into a measured dir."""
+        panel = self._make_panel()
+        panel.measure_dir_size('measured')
+        # Simulate a file being copied/moved into the measured dir.
+        (self.measured / 'b.txt').write_text('world')
+        self._bump_mtime(self.measured)
+        self.assertIsNone(panel.get_cached_dir_size('measured'))
+
+    def test_get_cached_returns_none_after_file_removed_from_dir(self) -> None:
+        """Regression test for issue #46: F8 inside a measured dir."""
+        panel = self._make_panel()
+        panel.measure_dir_size('measured')
+        (self.measured / 'a.txt').unlink()
+        self._bump_mtime(self.measured)
+        self.assertIsNone(panel.get_cached_dir_size('measured'))
+
+    def test_get_cached_returns_none_when_dir_deleted(self) -> None:
+        import shutil
+        panel = self._make_panel()
+        panel.measure_dir_size('measured')
+        shutil.rmtree(self.measured)
+        self.assertIsNone(panel.get_cached_dir_size('measured'))
+        # Stale entry should have been dropped from the internal cache.
+        resolved = (self.root / 'measured').resolve()
+        self.assertNotIn(resolved, panel._dir_size_cache)
+
+    def test_measure_dir_size_records_mtime_in_cache(self) -> None:
+        panel = self._make_panel()
+        size = panel.measure_dir_size('measured')
+        resolved = self.measured.resolve()
+        entry = panel._dir_size_cache.get(resolved)
+        self.assertIsNotNone(entry)
+        cached_size, cached_mtime = entry
+        self.assertEqual(cached_size, size)
+        self.assertAlmostEqual(cached_mtime, self.measured.stat().st_mtime, places=6)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tnc/panel.py
+++ b/tnc/panel.py
@@ -138,9 +138,13 @@ class Panel:
         # Back/forward stacks for Alt+Left / Alt+Right history navigation
         self._back_stack: list[Path] = []
         self._forward_stack: list[Path] = []
-        # Cached directory sizes: maps full path -> size in bytes
-        # Persists for the entire session (not cleared on directory change)
-        self._dir_size_cache: dict[Path, int] = {}
+        # Cached directory sizes: maps full path -> (size_in_bytes, mtime).
+        # Persists for the entire session (not cleared on directory change),
+        # but each cache hit revalidates against the directory's current
+        # mtime so F5/F6/F8 against a measured dir don't leave stale numbers
+        # on screen (issue #46). External shell-driven changes are also
+        # caught via the same mtime check.
+        self._dir_size_cache: dict[Path, tuple[int, float]] = {}
         # Render position tracking for mouse hit detection
         self.render_x: int = 0
         self.render_y: int = 0
@@ -871,6 +875,9 @@ class Panel:
     def measure_dir_size(self, name: str) -> int:
         """Calculate and cache the size of a directory.
 
+        The cache stores (size, mtime) so subsequent reads can detect when
+        the directory has been modified and invalidate themselves.
+
         Args:
             name: Name of the directory to measure.
 
@@ -880,20 +887,37 @@ class Panel:
         dir_path = (self.path / name).resolve()
         size = calculate_dir_size(dir_path)
         if size >= 0:
-            self._dir_size_cache[dir_path] = size
+            try:
+                mtime = dir_path.stat().st_mtime
+            except OSError:
+                # Don't cache an entry we can't validate against later.
+                return size
+            self._dir_size_cache[dir_path] = (size, mtime)
         return size
 
     def get_cached_dir_size(self, name: str) -> int | None:
-        """Get cached directory size if available.
+        """Get cached directory size if still valid.
 
-        Args:
-            name: Name of the directory.
-
-        Returns:
-            Size in bytes if cached, None otherwise.
+        Revalidates by comparing the directory's current mtime to the
+        mtime captured at measurement time. Mismatch (or stat failure)
+        drops the entry and returns None so the caller treats the dir as
+        unmeasured. This catches F5/F6/F8 against the measured dir as
+        well as external mutations (issue #46).
         """
         dir_path = (self.path / name).resolve()
-        return self._dir_size_cache.get(dir_path)
+        entry = self._dir_size_cache.get(dir_path)
+        if entry is None:
+            return None
+        size, cached_mtime = entry
+        try:
+            current_mtime = dir_path.stat().st_mtime
+        except OSError:
+            self._dir_size_cache.pop(dir_path, None)
+            return None
+        if current_mtime != cached_mtime:
+            self._dir_size_cache.pop(dir_path, None)
+            return None
+        return size
 
     def delete_selected(self) -> DeleteResult:
         """Delete selected files or current file if nothing selected.


### PR DESCRIPTION
## Summary
- Add mtime-based revalidation to `Panel._dir_size_cache` so the size shown after Alt+F3 stays correct after F5/F6/F8 against the measured directory.
- Cache value type changes from `int` to `tuple[int, float]`. On every cache hit, `get_cached_dir_size()` stats the dir and drops the entry if mtime advanced or stat failed.
- No new public API; no behavior change for unchanged directories.

## Related Issue
Closes #46

## Root cause
`Panel._dir_size_cache` lives for the whole session and was never invalidated — `change_directory()` even has a comment that the cache *"is NOT cleared - it persists for the session"* (`tnc/panel.py:694`). After any modification to a measured directory's contents, `get_cached_dir_size()` kept returning the old value, and `Panel.refresh()` rendered it on every paint.

## Changes Made
- `tnc/panel.py:143` — `_dir_size_cache` typed as `dict[Path, tuple[int, float]]`.
- `tnc/panel.py:measure_dir_size()` — stats the dir after computing size, stores `(size, mtime)`. If stat fails, returns the size without caching (don't poison the cache with an unverifiable entry).
- `tnc/panel.py:get_cached_dir_size()` — unpacks `(size, cached_mtime)`, stats the dir, drops the entry on stat failure or mtime mismatch and returns `None`.
- `tests/test_dir_size.py` — new `TestDirSizeCacheInvalidation` class with 5 regression tests using a real `tempfile.TemporaryDirectory` and a real `Panel`. Direct repros for: F5-into-measured, F8-inside-measured, dir deletion, fresh-hit, and the (size, mtime) cache shape.

## Architectural decisions
- **Tuple over dataclass** — both fields are always set/read together; a dataclass is over-engineered for an internal cache value.
- **Revalidate on read, not on write** — `measure_dir_size()` always overwrites with fresh data, so it doesn't need its own validation step. Reads happen during render, where one stat per cached dir per redraw is negligible.
- **Drop entry + return None on stat failure** — better to show no size than a wrong one when the dir is gone or unreachable.

## Out of scope (deferred)
- Nested-only tnc mutations: measure `/foo`, then F5 into `/foo/bar/baz`. Only the sub-sub-dir's mtime advances, so `/foo`'s cached entry still looks fresh. Documented in the [Phase 1 issue comment](https://github.com/efimsky/tiny-commander/issues/46#issuecomment-4405300814); promote to a follow-up issue if it surfaces in practice.
- In-place file-content-only mutations within a measured dir (parent mtime unchanged) — same edge-case class, same reasoning.

## Testing Done
- [x] **RED:** New tests fail before the implementation — `assertIsNone … 5 is not None` × 3 (cache returns the stale int) plus a tuple-unpack ERROR. Confirms tests target the bug.
- [x] **GREEN:** `python3.14 -m unittest tests.test_dir_size -v` — 18/18 pass (13 prior + 5 new).
- [x] **Full suite:** `python3.14 -m unittest discover -s tests` — 1161 ran, only the 4 pre-existing baseline failures (`test_edit_textedit_maps_to_open_e`, three `test_mouse` mock-setup tests). No new failures.
- [x] **Direct repro proof:**
  ```
  measured size: 100
  cached (no change): 100
  cached (after add+mtime bump): None
  ```

## Breaking Changes
None. The cache is a private attribute (`_dir_size_cache`); no external callers depend on the value type. Public methods (`measure_dir_size`, `get_cached_dir_size`) keep their signatures.

## Checklist
- [x] Code follows project conventions (zero deps, stdlib only, TDD)
- [x] Tests added (5 new in `TestDirSizeCacheInvalidation`)
- [x] Documentation updated — none needed; CLAUDE.md doesn't describe internal cache semantics
- [x] No secrets committed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)