### PR TITLE
feat(modal): mouse + arrow-key support across all modals (#16)

### DIFF
--- a/tests/test_chmod_dialog.py
+++ b/tests/test_chmod_dialog.py
@@ -213,5 +213,109 @@ class TestChmodDialogRecursive(unittest.TestCase):
         self.assertFalse(dialog.recursive)
 
 
+class TestChmodDialogMouse(unittest.TestCase):
+    """Issue #16: ChmodDialog gains click-on-checkbox / OK / Cancel.
+
+    These tests look up hit regions in `_click_targets` by action id rather
+    than assuming layout pixel positions, so they survive future layout
+    tweaks as long as the action ids stay the same.
+    """
+
+    def _setup(self, has_directory=False, initial_mode=0o644):
+        d = ChmodDialog(
+            file_count=1,
+            initial_mode=initial_mode,
+            has_directory=has_directory,
+            filename='file.txt',
+        )
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        return d, win
+
+    def _click(self, win, x, y):
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        return mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        )
+
+    def _hit_region(self, dialog, action_id):
+        """Return (mid_x, y) from the recorded click target for action_id."""
+        for x_start, x_end, y, target_id in dialog._click_targets:
+            if target_id == action_id:
+                return ((x_start + x_end) // 2, y)
+        raise AssertionError(f'No click target for {action_id!r}')
+
+    def test_click_on_grid_checkbox_toggles_it(self):
+        d, win = self._setup()
+        d.render(win)
+        # owner_read at grid:0:0; in 0o644 it's CHECKED (read=4 in owner=6).
+        before = d.get_bit_state('owner_read')
+        x, y = self._hit_region(d, 'grid:0:0')
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]  # click then Esc
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            d.show(win)
+        after = d.get_bit_state('owner_read')
+        self.assertNotEqual(before, after)
+
+    def test_click_on_special_checkbox_toggles_it(self):
+        d, win = self._setup()
+        d.render(win)
+        before = d.get_bit_state('setuid')
+        x, y = self._hit_region(d, 'special:0')
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            d.show(win)
+        self.assertNotEqual(d.get_bit_state('setuid'), before)
+
+    def test_click_on_recursive_checkbox_toggles_it(self):
+        d, win = self._setup(has_directory=True)
+        d.render(win)
+        self.assertFalse(d.recursive)
+        x, y = self._hit_region(d, 'recursive')
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            d.show(win)
+        self.assertTrue(d.recursive)
+
+    def test_click_on_ok_returns_mode(self):
+        d, win = self._setup(initial_mode=0o755)
+        d.render(win)
+        x, y = self._hit_region(d, 'ok')
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertEqual(d.show(win), 0o755)
+
+    def test_click_on_cancel_returns_none(self):
+        d, win = self._setup()
+        d.render(win)
+        x, y = self._hit_region(d, 'cancel')
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertIsNone(d.show(win))
+
+    def test_existing_arrow_navigation_preserved(self):
+        """Regression: arrow Down moves grid cursor row down."""
+        d, win = self._setup()
+        # Start: focus_section='grid', cursor_row=0, cursor_col=0
+        d.handle_key(curses.KEY_DOWN)
+        self.assertEqual(d.cursor_row, 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_chown_dialog.py
+++ b/tests/test_chown_dialog.py
@@ -146,5 +146,86 @@ class TestChownDialogResult(unittest.TestCase):
         self.assertEqual(result, ('alice', 'staff'))
 
 
+class TestChownDialogMouse(unittest.TestCase):
+    """Issue #16: ChownDialog gains click on owner field, group field, OK,
+    and Cancel."""
+
+    def _setup(self):
+        d = ChownDialog(
+            file_count=1,
+            current_owner='alice',
+            current_group='staff',
+            users=['alice', 'bob', 'charlie'],
+            groups=['staff', 'wheel'],
+            filename='file.txt',
+        )
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        return d, win
+
+    def _hit(self, dialog, action_id):
+        for x_start, x_end, y, target in dialog._click_targets:
+            if target == action_id:
+                return ((x_start + x_end) // 2, y)
+        raise AssertionError(f'no click target for {action_id!r}')
+
+    def test_click_on_owner_field_focuses_owner(self):
+        d, win = self._setup()
+        d.active_field = 'group'  # start somewhere else
+        d.render(win)
+        x, y = self._hit(d, 'owner_field')
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]  # click then Esc
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            d.show(win)
+        self.assertEqual(d.active_field, 'owner')
+
+    def test_click_on_group_field_focuses_group(self):
+        d, win = self._setup()
+        d.active_field = 'owner'
+        d.render(win)
+        x, y = self._hit(d, 'group_field')
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            d.show(win)
+        self.assertEqual(d.active_field, 'group')
+
+    def test_click_on_ok_returns_tuple(self):
+        d, win = self._setup()
+        d.render(win)
+        x, y = self._hit(d, 'ok')
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertEqual(d.show(win), ('alice', 'staff'))
+
+    def test_click_on_cancel_returns_none(self):
+        d, win = self._setup()
+        d.render(win)
+        x, y = self._hit(d, 'cancel')
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, x, y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertIsNone(d.show(win))
+
+    def test_existing_tab_navigation_preserved(self):
+        """Regression: Tab still cycles owner → group → buttons."""
+        d, _ = self._setup()
+        self.assertEqual(d.active_field, 'owner')
+        d.handle_key(ord('\t'))
+        self.assertEqual(d.active_field, 'group')
+        d.handle_key(ord('\t'))
+        self.assertEqual(d.active_field, 'buttons')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_confirmation_dialog.py
+++ b/tests/test_confirmation_dialog.py
@@ -128,7 +128,8 @@ class TestDeleteConfirmationPromptFormat(unittest.TestCase):
     """Test delete confirmation shows [Y/n] format."""
 
     def test_single_file_prompt_format(self):
-        """Single file prompt should show [Y/n] format."""
+        """Single-file delete prompt renders the Yes/No button bar (issue #16
+        replaced the inline `[Y/n]` hint with explicit ButtonBar buttons)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             test_file = Path(tmpdir) / 'myfile.txt'
             test_file.write_text('content')
@@ -146,14 +147,14 @@ class TestDeleteConfirmationPromptFormat(unittest.TestCase):
 
                 app._prompt_delete()
 
-                # Check addstr was called with [Y/n] format somewhere in the dialog
                 calls = stdscr.addstr.call_args_list
                 all_text = ' '.join(str(c) for c in calls)
                 self.assertIn('Delete', all_text, "Should have a Delete prompt")
-                self.assertIn('[Y/n]', all_text, "Dialog should show [Y/n] format")
+                self.assertIn('[ Yes ]', all_text, "Dialog should render the Yes button")
+                self.assertIn('[ No ]', all_text, "Dialog should render the No button")
 
     def test_multiple_files_prompt_format(self):
-        """Multiple files prompt should show [Y/n] format."""
+        """Multi-file delete prompt also shows the Yes/No button bar."""
         with tempfile.TemporaryDirectory() as tmpdir:
             Path(tmpdir, 'file1.txt').write_text('1')
             Path(tmpdir, 'file2.txt').write_text('2')
@@ -172,11 +173,11 @@ class TestDeleteConfirmationPromptFormat(unittest.TestCase):
 
                 app._prompt_delete()
 
-                # Check addstr was called with [Y/n] format somewhere in the dialog
                 calls = stdscr.addstr.call_args_list
                 all_text = ' '.join(str(c) for c in calls)
                 self.assertIn('Delete', all_text, "Should have a Delete prompt")
-                self.assertIn('[Y/n]', all_text, "Dialog should show [Y/n] format")
+                self.assertIn('[ Yes ]', all_text, "Dialog should render the Yes button")
+                self.assertIn('[ No ]', all_text, "Dialog should render the No button")
 
 
 if __name__ == '__main__':

--- a/tests/test_confirmation_dialog.py
+++ b/tests/test_confirmation_dialog.py
@@ -150,8 +150,14 @@ class TestDeleteConfirmationPromptFormat(unittest.TestCase):
                 calls = stdscr.addstr.call_args_list
                 all_text = ' '.join(str(c) for c in calls)
                 self.assertIn('Delete', all_text, "Should have a Delete prompt")
-                self.assertIn('[ Yes ]', all_text, "Dialog should render the Yes button")
-                self.assertIn('[ No ]', all_text, "Dialog should render the No button")
+                # Issue #16 focus markers: focused button is `[< Yes >]`,
+                # unfocused is `[  No  ]`. Both have a 'Yes' / 'No' label
+                # surrounded by brackets.
+                self.assertIn('Yes', all_text, "Dialog should render the Yes button")
+                self.assertIn('No', all_text, "Dialog should render the No button")
+                # Default-yes delete prompt → Yes is focused → angle markers.
+                self.assertIn('[< Yes >]', all_text,
+                              "Focused Yes button should have mc-style focus markers")
 
     def test_multiple_files_prompt_format(self):
         """Multi-file delete prompt also shows the Yes/No button bar."""
@@ -176,8 +182,10 @@ class TestDeleteConfirmationPromptFormat(unittest.TestCase):
                 calls = stdscr.addstr.call_args_list
                 all_text = ' '.join(str(c) for c in calls)
                 self.assertIn('Delete', all_text, "Should have a Delete prompt")
-                self.assertIn('[ Yes ]', all_text, "Dialog should render the Yes button")
-                self.assertIn('[ No ]', all_text, "Dialog should render the No button")
+                self.assertIn('Yes', all_text, "Dialog should render the Yes button")
+                self.assertIn('No', all_text, "Dialog should render the No button")
+                self.assertIn('[< Yes >]', all_text,
+                              "Focused Yes button should have mc-style focus markers")
 
 
 if __name__ == '__main__':

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -745,6 +745,58 @@ class TestMockDialogProvider(unittest.TestCase):
         self.assertEqual(result, 'nano')
 
 
+class TestErrorDialogMouse(unittest.TestCase):
+    """Issue #16: ErrorModal click on OK dismisses; outside clicks ignored;
+    any-key dismiss preserved (back-compat with `getch.return_value=q` tests)."""
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_ok_dismisses(self, _attr):
+        from tnc.dialog import ErrorModal
+        modal = ErrorModal('Error', 'something failed')
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        modal.render(win)
+        x_start, x_end, btn_y, _ = modal.button_bar.button_positions[0]
+        midx = (x_start + x_end) // 2
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertIsNone(modal.show(win))
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_outside_modal_does_not_dismiss(self, _attr):
+        """Click at (0,0) — well outside the dialog — must keep the loop alive.
+        We follow it with a key press to terminate so the test can assert."""
+        from tnc.dialog import ErrorModal
+        modal = ErrorModal('Error', 'something failed')
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        win.getch.side_effect = [curses.KEY_MOUSE, ord('q')]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, 0, 0, 0, curses.BUTTON1_CLICKED),
+        ):
+            modal.show(win)
+        # Two getch calls: outside click ignored, then 'q' dismisses.
+        self.assertEqual(win.getch.call_count, 2)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_any_key_dismisses_back_compat(self, _attr):
+        """Existing tests stub `getch.return_value = ord('q')` etc. Preserve."""
+        from tnc.dialog import show_error_dialog
+        for ch in [ord('q'), ord('\n'), 27, ord('x')]:
+            with self.subTest(ch=ch):
+                win = MagicMock()
+                win.getmaxyx.return_value = (24, 80)
+                win.getch.return_value = ch
+                # Should return without raising.
+                show_error_dialog(win, 'Error', 'msg')
+
+
 class TestOverwriteDialogMouse(unittest.TestCase):
     """Issue #16: OverwriteModal must respond to mouse clicks and arrow keys
     while preserving y/n/a/s/o/Esc shortcuts."""

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -745,6 +745,92 @@ class TestMockDialogProvider(unittest.TestCase):
         self.assertEqual(result, 'nano')
 
 
+class TestOverwriteDialogMouse(unittest.TestCase):
+    """Issue #16: OverwriteModal must respond to mouse clicks and arrow keys
+    while preserving y/n/a/s/o/Esc shortcuts."""
+
+    def _build_modal(self):
+        from tnc.dialog import OverwriteModal
+        return OverwriteModal(
+            filename='file.txt',
+            source_size=1024,
+            dest_size=2048,
+            source_mtime=1000.0,
+            dest_mtime=900.0,
+            current=1,
+            total=1,
+        )
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_each_of_five_buttons_returns_correct_choice(self, _attr):
+        from tnc.file_ops import OverwriteChoice
+        expected = [
+            OverwriteChoice.YES,
+            OverwriteChoice.NO,
+            OverwriteChoice.YES_ALL,
+            OverwriteChoice.NO_ALL,
+            OverwriteChoice.YES_OLDER,
+        ]
+
+        for choice in expected:
+            with self.subTest(choice=choice):
+                modal = self._build_modal()
+                win = MagicMock()
+                win.getmaxyx.return_value = (24, 80)
+                modal.render(win)
+                # Locate this button by value in the bar's hit-region cache.
+                entry = next(
+                    e for e in modal.button_bar.button_positions if e[3] == choice
+                )
+                x_start, x_end, btn_y, _ = entry
+                midx = (x_start + x_end) // 2
+
+                win.getch.side_effect = [curses.KEY_MOUSE]
+                with patch(
+                    'curses.getmouse',
+                    return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED),
+                ):
+                    self.assertEqual(modal.show(win), choice)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_arrow_keys_cycle_then_enter_activates(self, _attr):
+        from tnc.file_ops import OverwriteChoice
+        modal = self._build_modal()
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        # Start at Yes (focus 0). Right twice → All (index 2). Enter activates.
+        win.getch.side_effect = [
+            curses.KEY_RIGHT, curses.KEY_RIGHT, ord('\n'),
+        ]
+        self.assertEqual(modal.show(win), OverwriteChoice.YES_ALL)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_existing_letter_shortcuts_preserved(self, _attr):
+        from tnc.dialog import overwrite_dialog
+        from tnc.file_ops import OverwriteChoice
+        cases = [
+            (ord('y'), OverwriteChoice.YES), (ord('Y'), OverwriteChoice.YES),
+            (ord('n'), OverwriteChoice.NO),  (ord('N'), OverwriteChoice.NO),
+            (ord('a'), OverwriteChoice.YES_ALL),
+            (ord('s'), OverwriteChoice.NO_ALL),
+            (ord('o'), OverwriteChoice.YES_OLDER),
+            (27, OverwriteChoice.CANCEL),
+        ]
+        for ch, expected in cases:
+            with self.subTest(ch=ch):
+                win = MagicMock()
+                win.getmaxyx.return_value = (24, 80)
+                win.getch.side_effect = [ch]
+                self.assertEqual(
+                    overwrite_dialog(
+                        win, 'file.txt', 1024, 2048,
+                        source_mtime=1000.0, dest_mtime=900.0,
+                        current=1, total=1,
+                    ),
+                    expected,
+                )
+
+
 class TestConfirmDialogMouse(unittest.TestCase):
     """Issue #16: ConfirmModal must respond to mouse clicks and arrow keys
     while keeping the original y/n/Esc/Enter shortcuts."""

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -745,6 +745,81 @@ class TestMockDialogProvider(unittest.TestCase):
         self.assertEqual(result, 'nano')
 
 
+class TestSelectionDialogMouse(unittest.TestCase):
+    """Issue #16: SelectionDialog gains arrow-key + click navigation while
+    keeping the digit shortcuts and Esc behaviour."""
+
+    def _setup(self, options=None, allow_custom=False):
+        from tnc.dialog import SelectionDialog
+        d = SelectionDialog(
+            title='Pick',
+            options=options or ['nano', 'vim', 'emacs'],
+            allow_custom=allow_custom,
+        )
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        return d, win
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_option_returns_that_option(self, _attr):
+        d, win = self._setup()
+        d.render(win)
+        # Click in the middle of the second option's row.
+        x_start, x_end, row_y, _ = d.option_positions[1]
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, midx, row_y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertEqual(d.show(win), 'vim')
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_arrow_down_then_enter_activates_focused(self, _attr):
+        d, win = self._setup()
+        # Initial focus = 0 (nano). Down-Down → emacs (index 2). Enter activates.
+        win.getch.side_effect = [
+            curses.KEY_DOWN, curses.KEY_DOWN, ord('\n'),
+        ]
+        self.assertEqual(d.show(win), 'emacs')
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_arrow_up_wraps_to_last(self, _attr):
+        d, win = self._setup()
+        # From focus 0, Up wraps to last (index 2 = emacs). Enter activates.
+        win.getch.side_effect = [curses.KEY_UP, ord('\n')]
+        self.assertEqual(d.show(win), 'emacs')
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_existing_digit_shortcut_returns_option(self, _attr):
+        """Regression test: digits still map directly to options."""
+        d, _ = self._setup()
+        self.assertEqual(d.handle_key(ord('2')), 'vim')
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_custom_option_enters_custom_mode(self, _attr):
+        d, win = self._setup(allow_custom=True)
+        d.render(win)
+        # Find the custom row.
+        custom_entry = next(
+            e for e in d.option_positions if e[3] == 'custom'
+        )
+        x_start, x_end, row_y, _ = custom_entry
+        midx = (x_start + x_end) // 2
+
+        # Click → enter custom mode; Esc in custom mode exits to normal
+        # mode (does NOT cancel); a second Esc in normal mode cancels.
+        win.getch.side_effect = [curses.KEY_MOUSE, 27, 27]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, midx, row_y, 0, curses.BUTTON1_CLICKED),
+        ):
+            self.assertIsNone(d.show(win))
+        # Loop ran: click, Esc-leave-custom, Esc-cancel = 3 getch calls.
+        self.assertEqual(win.getch.call_count, 3)
+
+
 class TestSummaryDialogMouse(unittest.TestCase):
     """Issue #16: SummaryModal click-on-message-row dismisses; clicks
     elsewhere are ignored; any key still dismisses."""

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -1,6 +1,8 @@
 """Tests for dialog module."""
 
+import curses
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock, patch, call
 
 
@@ -741,6 +743,111 @@ class TestMockDialogProvider(unittest.TestCase):
         result = mock_provider.select('Select editor', ['nano', 'vim'])
 
         self.assertEqual(result, 'nano')
+
+
+class TestConfirmDialogMouse(unittest.TestCase):
+    """Issue #16: ConfirmModal must respond to mouse clicks and arrow keys
+    while keeping the original y/n/Esc/Enter shortcuts."""
+
+    def _click_at(self, win, target_x: int, target_y: int):
+        """Helper: rig getch to issue ONE KEY_MOUSE event for (target_x, target_y)
+        with BUTTON1_CLICKED, followed by Esc as a safety terminator."""
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+        return mock.patch(
+            'curses.getmouse',
+            return_value=(0, target_x, target_y, 0, curses.BUTTON1_CLICKED),
+        )
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_yes_button_returns_true(self, _get_attr):
+        from tnc.dialog import ConfirmModal
+        modal = ConfirmModal('Title', 'msg', default_yes=True)
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        # Render once so the button bar records hit regions.
+        modal.render(win)
+        # Pick the visible Yes button position.
+        yes_entry = next(
+            e for e in modal.button_bar.button_positions if e[3] is True
+        )
+        x_start, x_end, btn_y, _ = yes_entry
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with patch('curses.getmouse',
+                   return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED)):
+            result = modal.show(win)
+
+        self.assertIs(result, True)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_no_button_returns_false(self, _get_attr):
+        from tnc.dialog import ConfirmModal
+        modal = ConfirmModal('Title', 'msg', default_yes=True)
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        modal.render(win)
+        no_entry = next(
+            e for e in modal.button_bar.button_positions if e[3] is False
+        )
+        x_start, x_end, btn_y, _ = no_entry
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with patch('curses.getmouse',
+                   return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED)):
+            result = modal.show(win)
+
+        self.assertIs(result, False)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_outside_modal_does_nothing_then_y_returns_true(self, _get_attr):
+        """A click that misses every button keeps the loop alive; the next y
+        keystroke returns True. This proves outside clicks are ignored."""
+        from tnc.dialog import ConfirmModal
+        modal = ConfirmModal('Title', 'msg', default_yes=True)
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        # Mouse click at (0, 0) — well outside the modal box.
+        win.getch.side_effect = [curses.KEY_MOUSE, ord('y')]
+        with patch('curses.getmouse',
+                   return_value=(0, 0, 0, 0, curses.BUTTON1_CLICKED)):
+            result = modal.show(win)
+
+        self.assertIs(result, True)
+        # render was called twice: once before the click, once before the 'y'.
+        self.assertEqual(win.getch.call_count, 2)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_arrow_keys_cycle_focus_then_enter_activates(self, _get_attr):
+        from tnc.dialog import ConfirmModal
+        modal = ConfirmModal('Title', 'msg', default_yes=True)
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        # Default focus = Yes (index 0). Arrow Right moves to No, Enter activates.
+        win.getch.side_effect = [curses.KEY_RIGHT, ord('\n')]
+        result = modal.show(win)
+        self.assertIs(result, False)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_existing_y_n_esc_enter_keys_preserved(self, _get_attr):
+        """Regression test — the keyboard contract from before #16 still works."""
+        from tnc.dialog import confirm_dialog
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+
+        for ch, expected in [(ord('y'), True), (ord('Y'), True),
+                             (ord('n'), False), (ord('N'), False),
+                             (27, False)]:
+            with self.subTest(ch=ch):
+                win.getch.side_effect = [ch]
+                self.assertEqual(
+                    confirm_dialog(win, 'Title', 'msg'), expected
+                )
 
 
 if __name__ == '__main__':

--- a/tests/test_dialog.py
+++ b/tests/test_dialog.py
@@ -745,6 +745,49 @@ class TestMockDialogProvider(unittest.TestCase):
         self.assertEqual(result, 'nano')
 
 
+class TestSummaryDialogMouse(unittest.TestCase):
+    """Issue #16: SummaryModal click-on-message-row dismisses; clicks
+    elsewhere are ignored; any key still dismisses."""
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_on_message_row_dismisses(self, _attr):
+        from tnc.dialog import show_summary
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        # Bottom row is y=23 (24-1).
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, 5, 23, 0, curses.BUTTON1_CLICKED),
+        ):
+            show_summary(win, 'copy', copied=3)
+        self.assertEqual(win.getch.call_count, 1)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_click_above_message_row_is_ignored(self, _attr):
+        from tnc.dialog import show_summary
+        win = MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        # First click at row 5 (panel area) — ignored. Then 'q' dismisses.
+        win.getch.side_effect = [curses.KEY_MOUSE, ord('q')]
+        with patch(
+            'curses.getmouse',
+            return_value=(0, 5, 5, 0, curses.BUTTON1_CLICKED),
+        ):
+            show_summary(win, 'copy', copied=3)
+        self.assertEqual(win.getch.call_count, 2)
+
+    @patch('tnc.dialog.get_attr', return_value=0)
+    def test_any_key_dismisses_back_compat(self, _attr):
+        from tnc.dialog import show_summary
+        for ch in [ord('q'), ord('\n'), 27, ord(' ')]:
+            with self.subTest(ch=ch):
+                win = MagicMock()
+                win.getmaxyx.return_value = (24, 80)
+                win.getch.return_value = ch
+                show_summary(win, 'move', moved=1)
+
+
 class TestErrorDialogMouse(unittest.TestCase):
     """Issue #16: ErrorModal click on OK dismisses; outside clicks ignored;
     any-key dismiss preserved (back-compat with `getch.return_value=q` tests)."""

--- a/tests/test_input_dialog.py
+++ b/tests/test_input_dialog.py
@@ -368,5 +368,70 @@ class TestInputDialogConvenienceFunction(unittest.TestCase):
         self.assertEqual(result, 'hello')
 
 
+class TestInputDialogMouse(unittest.TestCase):
+    """Issue #16: InputDialog gains click-on-OK/Cancel and click-in-field
+    cursor repositioning while preserving typing/Enter/Esc behaviour."""
+
+    def _setup(self, default_value=''):
+        d = InputDialog('Title', 'Prompt:', default_value=default_value)
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        return d, win
+
+    def test_click_on_ok_returns_text(self):
+        d, win = self._setup(default_value='hello')
+        d.render(win)
+        ok_entry = next(e for e in d.button_bar.button_positions if e[3] == '<OK>')
+        x_start, x_end, btn_y, _ = ok_entry
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch('curses.curs_set'), \
+             mock.patch('curses.getmouse',
+                        return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED)):
+            self.assertEqual(d.show(win), 'hello')
+
+    def test_click_on_cancel_returns_none(self):
+        d, win = self._setup(default_value='hello')
+        d.render(win)
+        cancel_entry = next(
+            e for e in d.button_bar.button_positions if e[3] == '<CANCEL>'
+        )
+        x_start, x_end, btn_y, _ = cancel_entry
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch('curses.curs_set'), \
+             mock.patch('curses.getmouse',
+                        return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED)):
+            self.assertIsNone(d.show(win))
+
+    def test_click_in_text_field_repositions_cursor(self):
+        d, win = self._setup(default_value='helloworld')
+        d.render(win)
+        # Click 3 chars into the visible field.
+        click_x = d._field_x_start + 3
+        click_y = d._field_y
+
+        win.getch.side_effect = [curses.KEY_MOUSE, ord('\n')]
+        with mock.patch('curses.curs_set'), \
+             mock.patch('curses.getmouse',
+                        return_value=(0, click_x, click_y, 0, curses.BUTTON1_CLICKED)):
+            d.show(win)
+        # visible_start = 0 at default render, so click offset 3 → cursor 3.
+        self.assertEqual(d.cursor_pos, 3)
+
+    def test_existing_typing_enter_esc_preserved(self):
+        """Regression: Esc returns empty string, Enter accepts default text."""
+        from tnc.dialog import input_dialog
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (24, 80)
+        with mock.patch('curses.curs_set'):
+            win.getch.return_value = 27
+            self.assertEqual(input_dialog(win, 'T', 'P'), '')
+            win.getch.return_value = ord('\n')
+            self.assertEqual(input_dialog(win, 'T', 'P', default_value='hi'), 'hi')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -99,6 +99,28 @@ class TestButtonBar(unittest.TestCase):
             f'Focused Yes button must include A_REVERSE; saw attrs={attrs_used!r}',
         )
 
+    def test_focused_button_has_angle_markers_unfocused_has_spaces(self):
+        """mc-style focus indication: focused button renders as `[< label >]`,
+        unfocused as `[  label  ]`. Same width so layout doesn't shift on focus
+        change. Provides a redundant cue that survives monochrome terminals
+        and colorblindness."""
+        bar = self._make_bar(focused=0)
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        rendered_texts = [
+            args[2]
+            for call in win.addstr.call_args_list
+            for args in [call[0]]
+            if len(args) >= 4 and isinstance(args[2], str) and (
+                'Yes' in args[2] or 'No' in args[2]
+            )
+        ]
+        self.assertIn('[< Yes >]', rendered_texts)
+        self.assertIn('[  No  ]', rendered_texts)
+        # Both variants are the same length so the bar layout is stable.
+        self.assertEqual(len('[< Yes >]'), len('[  Yes  ]'))
+
 
 class TestModalBase(unittest.TestCase):
     """Modal.show(): single loop drives render, getch, mouse routing."""

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -1,0 +1,188 @@
+"""Tests for the Modal base class and ButtonBar widget (issue #16)."""
+
+import curses
+import unittest
+from unittest import mock
+
+
+class TestButtonBar(unittest.TestCase):
+    """ButtonBar widget: focus, hit-test, render-records-positions."""
+
+    def _make_bar(self, focused: int = 0):
+        from tnc.modal import Button, ButtonBar
+        return ButtonBar(
+            buttons=[
+                Button(label='Yes', shortcut='y', value=True),
+                Button(label='No', shortcut='n', value=False),
+            ],
+            focused=focused,
+        )
+
+    def test_render_records_hit_regions(self):
+        bar = self._make_bar()
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        # Two buttons → two entries.
+        self.assertEqual(len(bar.button_positions), 2)
+        for entry in bar.button_positions:
+            x_start, x_end, y, value = entry
+            self.assertIsInstance(x_start, int)
+            self.assertIsInstance(x_end, int)
+            self.assertEqual(y, 10)
+            self.assertLess(x_start, x_end)
+
+    def test_hit_test_returns_value_for_inside_x(self):
+        bar = self._make_bar()
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        first_x_start, first_x_end, _, first_value = bar.button_positions[0]
+        # Click in the middle of the first button.
+        midx = (first_x_start + first_x_end) // 2
+        self.assertEqual(bar.hit_test(midx, 10), first_value)
+
+    def test_hit_test_returns_none_for_wrong_y(self):
+        bar = self._make_bar()
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        midx = (bar.button_positions[0][0] + bar.button_positions[0][1]) // 2
+        self.assertIsNone(bar.hit_test(midx, 9))
+        self.assertIsNone(bar.hit_test(midx, 11))
+
+    def test_hit_test_returns_none_for_outside_x(self):
+        bar = self._make_bar()
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        last_x_end = bar.button_positions[-1][1]
+        self.assertIsNone(bar.hit_test(last_x_end + 5, 10))
+        self.assertIsNone(bar.hit_test(0, 10))
+
+    def test_move_focus_wraps(self):
+        bar = self._make_bar(focused=0)
+        bar.move_focus(-1)
+        self.assertEqual(bar.focused, 1)  # wraps from 0 -> last
+        bar.move_focus(1)
+        self.assertEqual(bar.focused, 0)  # wraps from last -> 0
+        bar.move_focus(1)
+        self.assertEqual(bar.focused, 1)
+
+    def test_activate_returns_focused_value(self):
+        bar = self._make_bar(focused=1)
+        self.assertEqual(bar.activate(), False)  # No
+        bar.focused = 0
+        self.assertEqual(bar.activate(), True)   # Yes
+
+    def test_activate_by_shortcut_returns_value(self):
+        bar = self._make_bar()
+        self.assertEqual(bar.activate_by_shortcut('y'), True)
+        self.assertEqual(bar.activate_by_shortcut('Y'), True)
+        self.assertEqual(bar.activate_by_shortcut('n'), False)
+        self.assertIsNone(bar.activate_by_shortcut('q'))
+
+    def test_focused_button_rendered_with_reverse_attribute(self):
+        bar = self._make_bar(focused=0)
+        win = mock.MagicMock()
+        bar.render(win, y=10, x_start=20, total_width=40)
+
+        # Inspect the addstr calls; the first button should have included
+        # curses.A_REVERSE in its attribute argument.
+        attrs_used = []
+        for call in win.addstr.call_args_list:
+            args = call[0]
+            if len(args) >= 4 and isinstance(args[2], str) and 'Yes' in args[2]:
+                attrs_used.append(args[3])
+        self.assertTrue(
+            any(attr & curses.A_REVERSE for attr in attrs_used),
+            f'Focused Yes button must include A_REVERSE; saw attrs={attrs_used!r}',
+        )
+
+
+class TestModalBase(unittest.TestCase):
+    """Modal.show(): single loop drives render, getch, mouse routing."""
+
+    def _make_modal_class(self):
+        from tnc.modal import Modal
+
+        class Spy(Modal):
+            def __init__(self):
+                super().__init__()
+                self.render_calls = 0
+                self.handle_key_calls = []
+                self.handle_click_calls = []
+
+            def render(self, win):
+                self.render_calls += 1
+
+            def handle_key(self, key):
+                self.handle_key_calls.append(key)
+                # Quit on Esc to terminate the loop deterministically.
+                if key == 27:
+                    self.set_result('cancelled')
+
+            def handle_click(self, x, y, button_state):
+                self.handle_click_calls.append((x, y, button_state))
+
+        return Spy
+
+    def test_show_loop_calls_render_before_each_getch(self):
+        Spy = self._make_modal_class()
+        m = Spy()
+        win = mock.MagicMock()
+        win.getch.side_effect = [ord('a'), ord('b'), 27]  # 27 = Esc
+
+        m.show(win)
+
+        self.assertEqual(m.render_calls, 3)
+        self.assertEqual(m.handle_key_calls, [ord('a'), ord('b'), 27])
+
+    def test_key_mouse_routes_to_handle_click(self):
+        Spy = self._make_modal_class()
+        m = Spy()
+        win = mock.MagicMock()
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+
+        with mock.patch('curses.getmouse', return_value=(0, 5, 7, 0, curses.BUTTON1_CLICKED)):
+            m.show(win)
+
+        self.assertEqual(m.handle_click_calls, [(5, 7, curses.BUTTON1_CLICKED)])
+        # Mouse event was NOT also sent to handle_key.
+        self.assertEqual(m.handle_key_calls, [27])
+
+    def test_key_mouse_with_failed_getmouse_is_dropped(self):
+        Spy = self._make_modal_class()
+        m = Spy()
+        win = mock.MagicMock()
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+
+        with mock.patch('curses.getmouse', side_effect=curses.error('boom')):
+            m.show(win)
+
+        # No click dispatched, but the loop survived.
+        self.assertEqual(m.handle_click_calls, [])
+        self.assertEqual(m.handle_key_calls, [27])
+
+    def test_set_result_terminates_loop_and_show_returns_value(self):
+        from tnc.modal import Modal
+
+        class Quick(Modal):
+            def render(self, win):
+                pass
+
+            def handle_key(self, key):
+                self.set_result(42)
+
+            def handle_click(self, x, y, button_state):
+                pass
+
+        win = mock.MagicMock()
+        win.getch.return_value = ord('x')
+
+        result = Quick().show(win)
+        self.assertEqual(result, 42)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -1837,12 +1837,17 @@ def chown_dialog(
     return dialog.show(win)
 
 
-class InputDialog:
+class InputDialog(Modal):
     """A modal text input dialog with full editing support.
 
-    Displays a centered dialog box with a title, prompt text, and an
-    editable text field. Supports cursor movement (arrows, Home/End),
-    character deletion (Backspace, Delete), and text insertion at cursor.
+    Displays a centered dialog box with a title, prompt text, an editable
+    text field, and an OK / Cancel button row. Supports cursor movement
+    (arrows, Home/End), character deletion (Backspace, Delete), and text
+    insertion at cursor.
+
+    Issue #16: subclasses :class:`Modal` so it inherits mouse routing.
+    Click in the text field repositions the cursor; click OK/Cancel
+    activates them. Existing typing/Enter/Esc behaviour is preserved.
 
     Attributes:
         title: Dialog title displayed in the title bar.
@@ -1866,13 +1871,34 @@ class InputDialog:
             prompt: Prompt text shown above input field.
             default_value: Initial text in the input field.
         """
+        super().__init__()
         self.title = title
         self.prompt = prompt
         self.text = default_value
         self.cursor_pos = len(default_value)
+        # Coordinates cached during render() for click hit-testing.
+        self._field_y: int = -1
+        self._field_x_start: int = -1
+        self._field_x_end: int = -1
+        self._visible_start: int = 0
+        # OK/Cancel buttons. The OK value is the sentinel `'<OK>'`; the
+        # actual returned text is read from `self.text` when OK fires.
+        # (We can't put `self.text` in the Button at construction time
+        # because text changes as the user types.)
+        self.button_bar = ButtonBar(
+            buttons=[
+                Button(label='OK', shortcut='', value='<OK>'),
+                Button(label='Cancel', shortcut='', value='<CANCEL>'),
+            ],
+            focused=0,
+        )
 
     def handle_key(self, key: int) -> str | None:
-        """Handle a keypress and return result if dialog should close.
+        """Handle a keypress.
+
+        Returns the entered text (or empty) on Enter for back-compat with
+        existing tests. Internally also calls :meth:`Modal.set_result` so
+        the inherited :meth:`Modal.show` loop terminates correctly.
 
         Args:
             key: Key code from curses.
@@ -1880,15 +1906,16 @@ class InputDialog:
         Returns:
             - str: The input text (Enter pressed). May be empty.
             - None: Dialog should continue (character typed, cursor moved)
-              or dialog was cancelled (Escape). Callers should check the
-              key value to distinguish; see show() for the pattern.
+              or was cancelled (Escape).
         """
         # Enter confirms
         if key in (ord('\n'), ord('\r'), curses.KEY_ENTER):
+            self.set_result(self.text)
             return self.text
 
         # Escape cancels
         if key == 27:
+            self.set_result(None)
             return None
 
         # Backspace
@@ -1939,6 +1966,28 @@ class InputDialog:
 
         return None
 
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        """Click in the field repositions the cursor; click on a button activates it."""
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        # Click on OK / Cancel button.
+        value = self.button_bar.hit_test(x, y)
+        if value == '<OK>':
+            self.set_result(self.text)
+            return
+        if value == '<CANCEL>':
+            self.set_result(None)
+            return
+        # Click in the input field row → reposition cursor.
+        if (
+            y == self._field_y
+            and self._field_x_start <= x < self._field_x_end
+        ):
+            click_offset = x - self._field_x_start  # 0-based within visible
+            new_pos = self._visible_start + click_offset
+            new_pos = max(0, min(new_pos, len(self.text)))
+            self.cursor_pos = new_pos
+
     def render(self, stdscr: Any) -> None:
         """Render the dialog to the screen.
 
@@ -1974,8 +2023,6 @@ class InputDialog:
             input_display,
             '',
         ]
-
-        footer = '[Enter] OK  [Esc] Cancel'
 
         # Height: top + title + sep + empty + lines + footer_sep + footer + bottom
         height = 5 + len(lines) + 2
@@ -2015,16 +2062,25 @@ class InputDialog:
         footer_y = y + 4 + len(lines)
         safe_addstr(stdscr, footer_y, x, frame['separator'], dialog_attr)
 
-        # Footer
-        safe_addstr(stdscr, footer_y + 1, x,
-                    frame['content_line'](footer), dialog_attr)
+        # OK / Cancel button bar (replaces the old "[Enter] OK [Esc] Cancel"
+        # static hint). Issue #16: clickable + arrow-focusable buttons.
+        self.button_bar.render(
+            stdscr, y=footer_y + 1, x_start=x + 1, total_width=width - 2
+        )
 
         # Bottom border
         safe_addstr(stdscr, footer_y + 2, x, frame['bottom'], dialog_attr)
 
+        # Cache field coordinates for click-to-reposition (issue #16).
+        # Visible text starts after "│ > " (4 chars in).
+        self._field_y = y + 5
+        self._field_x_start = x + 4
+        self._field_x_end = x + 4 + max_text_len
+        self._visible_start = visible_start
+
         # Position cursor on the input field for visual feedback
-        cursor_y = y + 5  # Input line (prompt is y+4, input is y+5)
-        cursor_x = x + 4 + cursor_visual  # "│ > " = 4 chars offset
+        cursor_y = y + 5
+        cursor_x = self._field_x_start + cursor_visual
         try:
             stdscr.move(cursor_y, cursor_x)
         except curses.error:
@@ -2035,27 +2091,16 @@ class InputDialog:
     def show(self, stdscr: Any) -> str | None:
         """Show the dialog and handle input until confirmed or cancelled.
 
-        Args:
-            stdscr: Curses window.
-
-        Returns:
-            The entered text string on Enter, or None if cancelled (Escape).
+        Wraps the inherited :meth:`Modal.show` with a ``curs_set(1)`` /
+        ``curs_set(0)`` pair so the input cursor is visible while the
+        field has focus, and hidden again on exit.
         """
         try:
             curses.curs_set(1)
         except curses.error:
             pass
         try:
-            while True:
-                self.render(stdscr)
-                key = stdscr.getch()
-                result = self.handle_key(key)
-
-                if result is not None:
-                    return result
-
-                if key == 27:
-                    return None
+            return super().show(stdscr)
         finally:
             try:
                 curses.curs_set(0)

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -241,7 +241,8 @@ class ConfirmModal(Modal):
         box_y, box_x = draw_modal(win, self.title, body, width=self._width)
         btn_y = box_y + 3 + len(body) - 1
         self.button_bar.render(
-            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4,
+            base_attr=get_attr(PAIR_DIALOG),
         )
         win.refresh()
 
@@ -349,7 +350,8 @@ class OverwriteModal(Modal):
         box_y, box_x = draw_modal(win, self.title, body, width=self._width)
         btn_y = box_y + 3 + len(body) - 1
         self.button_bar.render(
-            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4,
+            base_attr=get_attr(PAIR_DIALOG),
         )
         win.refresh()
 
@@ -569,7 +571,8 @@ class ErrorModal(Modal):
         box_y, box_x = draw_modal(win, self.title, body, width=self._width)
         btn_y = box_y + 3 + len(body) - 1
         self.button_bar.render(
-            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4,
+            base_attr=get_attr(PAIR_DIALOG),
         )
         win.refresh()
 
@@ -2206,7 +2209,8 @@ class InputDialog(Modal):
         # OK / Cancel button bar (replaces the old "[Enter] OK [Esc] Cancel"
         # static hint). Issue #16: clickable + arrow-focusable buttons.
         self.button_bar.render(
-            stdscr, y=footer_y + 1, x_start=x + 1, total_width=width - 2
+            stdscr, y=footer_y + 1, x_start=x + 1, total_width=width - 2,
+            base_attr=dialog_attr,
         )
 
         # Bottom border

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -1598,10 +1598,15 @@ def chmod_dialog(
     return None
 
 
-class ChownDialog:
+class ChownDialog(Modal):
     """Dialog for changing file ownership.
 
     Displays text input fields for owner and group with autocomplete.
+
+    Issue #16: subclasses :class:`Modal` for mouse routing. Click on the
+    owner field, group field, OK, or Cancel does the obvious thing while
+    all existing keyboard navigation (Tab, arrows, Enter, Esc) is
+    preserved.
     """
 
     def __init__(
@@ -1625,6 +1630,7 @@ class ChownDialog:
         """
         from tnc.permissions import get_system_users, get_system_groups
 
+        super().__init__()
         self.file_count = file_count
         self.filename = filename
         self.owner_input = current_owner
@@ -1640,6 +1646,10 @@ class ChownDialog:
         self.cursor_pos = len(current_owner)
         self.autocomplete_index = -1  # -1 means no selection
         self.button_focus = 0  # 0=OK, 1=Cancel
+        # Click hit regions populated during render(); see ChmodDialog for the
+        # same pattern. Action ids used here:
+        #   'owner_field' | 'group_field' | 'ok' | 'cancel'.
+        self._click_targets: list[tuple[int, int, int, str]] = []
 
     def get_autocomplete_suggestions(self) -> list[str]:
         """Get autocomplete suggestions for current field."""
@@ -1654,6 +1664,10 @@ class ChownDialog:
     def handle_key(self, key: int) -> bool:
         """Handle a keypress.
 
+        Returns True when the dialog should close (back-compat with
+        existing tests). Also calls :meth:`Modal.set_result` so the
+        inherited :meth:`Modal.show` loop terminates correctly.
+
         Args:
             key: Key code from curses.
 
@@ -1665,6 +1679,7 @@ class ChownDialog:
         # Escape cancels
         if key == 27:
             self.cancelled = True
+            self.set_result(None)
             return True
 
         # Tab switches fields
@@ -1724,6 +1739,9 @@ class ChownDialog:
             elif self.active_field == 'buttons':
                 if self.button_focus == 1:  # Cancel
                     self.cancelled = True
+                    self.set_result(None)
+                else:
+                    self.set_result(self.get_result())
                 return True  # Close dialog
             else:
                 # Move to next field
@@ -1760,6 +1778,35 @@ class ChownDialog:
 
         return False
 
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        """Click on a registered hit region: focus field or activate button (#16)."""
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        for x_start, x_end, target_y, action_id in self._click_targets:
+            if y == target_y and x_start <= x < x_end:
+                self._activate_action(action_id)
+                return
+
+    def _activate_action(self, action_id: str) -> None:
+        """Apply the side effect of clicking the given hit region."""
+        if action_id == 'ok':
+            self.set_result(self.get_result())
+            return
+        if action_id == 'cancel':
+            self.cancelled = True
+            self.set_result(None)
+            return
+        if action_id == 'owner_field':
+            self.active_field = 'owner'
+            self.cursor_pos = len(self.owner_input)
+            self.autocomplete_index = -1
+            return
+        if action_id == 'group_field':
+            self.active_field = 'group'
+            self.cursor_pos = len(self.group_input)
+            self.autocomplete_index = -1
+            return
+
     def get_result(self) -> tuple[str, str]:
         """Get current owner and group values."""
         return (self.owner_input, self.group_input)
@@ -1785,6 +1832,9 @@ class ChownDialog:
         dialog_attr = get_attr(PAIR_DIALOG)
         title_attr = get_attr(PAIR_DIALOG_TITLE)
 
+        # Reset click hit-regions; rebuild as we render.
+        self._click_targets.clear()
+
         # Draw border and title
         title = 'Change Ownership'
         top_border = '┌─ ' + title + ' ' + '─' * (width - len(title) - 5) + '┐'
@@ -1807,11 +1857,17 @@ class ChownDialog:
         self._draw_line(win, line_y, start_x, width, '', dialog_attr)
         line_y += 1
 
-        # Owner field
+        # Owner field. _draw_line prefixes '│ ' (2 chars) at start_x. The
+        # content '  Owner: [<input padded to 20>]' puts the bracketed
+        # field at offset 2(border)+2(pad)+7(label) = 11. The field span
+        # including brackets is 22 chars (1 + 20 + 1).
         owner_label = 'Owner: '
         owner_field = self.owner_input + ('_' if self.active_field == 'owner' else '')
         owner_line = f'  {owner_label}[{owner_field.ljust(20)}]'
         self._draw_line(win, line_y, start_x, width, owner_line, dialog_attr)
+        self._click_targets.append(
+            (start_x + 11, start_x + 33, line_y, 'owner_field')
+        )
         line_y += 1
 
         # Autocomplete for owner
@@ -1826,11 +1882,14 @@ class ChownDialog:
         self._draw_line(win, line_y, start_x, width, '', dialog_attr)
         line_y += 1
 
-        # Group field
+        # Group field — same geometry as Owner.
         group_label = 'Group: '
         group_field = self.group_input + ('_' if self.active_field == 'group' else '')
         group_line = f'  {group_label}[{group_field.ljust(20)}]'
         self._draw_line(win, line_y, start_x, width, group_line, dialog_attr)
+        self._click_targets.append(
+            (start_x + 11, start_x + 33, line_y, 'group_field')
+        )
         line_y += 1
 
         # Autocomplete for group
@@ -1854,11 +1913,19 @@ class ChownDialog:
         self._draw_line(win, line_y, start_x, width, '', dialog_attr)
         line_y += 1
 
-        # Buttons
+        # Buttons. Same hit-region math as ChmodDialog.
         ok_btn = '[  OK  ]' if self.active_field != 'buttons' or self.button_focus != 0 else '[ >OK< ]'
         cancel_btn = '[Cancel]' if self.active_field != 'buttons' or self.button_focus != 1 else '[>Cancel<]'
-        buttons = f'{ok_btn}  {cancel_btn}'.center(width - 4)
+        button_pair = f'{ok_btn}  {cancel_btn}'
+        buttons = button_pair.center(width - 4)
         self._draw_line(win, line_y, start_x, width, buttons, dialog_attr)
+        leading_pad = (width - 4 - len(button_pair)) // 2
+        ok_x_start = start_x + 2 + leading_pad
+        ok_x_end = ok_x_start + len(ok_btn)
+        cancel_x_start = ok_x_end + 2
+        cancel_x_end = cancel_x_start + len(cancel_btn)
+        self._click_targets.append((ok_x_start, ok_x_end, line_y, 'ok'))
+        self._click_targets.append((cancel_x_start, cancel_x_end, line_y, 'cancel'))
         line_y += 1
 
         # Bottom border
@@ -1878,19 +1945,8 @@ class ChownDialog:
         except curses.error:
             pass
 
-    def show(self, win: Any) -> tuple[str, str] | None:
-        """Show dialog and handle input until done.
-
-        Returns:
-            Tuple of (owner, group) or None if cancelled.
-        """
-        while True:
-            self.render(win)
-            key = win.getch()
-            if self.handle_key(key):
-                if self.cancelled:
-                    return None
-                return self.get_result()
+    # show() inherited from Modal; the loop drives render → getch → handle_key
+    # / handle_click and terminates when set_result fires.
 
 
 def chown_dialog(

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -1091,11 +1091,16 @@ _GRID_BITS = [
 _SPECIAL_BITS = ['setuid', 'setgid', 'sticky']
 
 
-class ChmodDialog:
+class ChmodDialog(Modal):
     """Dialog for changing file permissions.
 
     Displays a checkbox grid for rwx permissions and special bits,
     with live octal mode preview.
+
+    Issue #16: subclasses :class:`Modal` so it inherits mouse routing.
+    Click on any checkbox toggles it (and moves focus there); click on
+    OK / Cancel activates them. All existing keyboard navigation
+    (arrows, Tab, Space, Enter, Esc) is preserved.
     """
 
     def __init__(
@@ -1117,6 +1122,7 @@ class ChmodDialog:
         """
         from tnc.permissions import TriState, get_permission_bits
 
+        super().__init__()
         self.file_count = file_count
         self.has_directory = has_directory
         self.filename = filename
@@ -1128,6 +1134,13 @@ class ChmodDialog:
         self.focus_section = 'grid'  # 'grid', 'special', 'recursive', 'buttons'
         self.button_focus = 0  # 0=OK, 1=Cancel
         self.cancelled = False
+        # Click hit regions populated during render(). Each entry is
+        # (x_start, x_end, y, action_id) where action_id is one of:
+        #   'grid:<row>:<col>'   (e.g. 'grid:0:0' = owner_read)
+        #   'special:<col>'      (e.g. 'special:0' = setuid)
+        #   'recursive'
+        #   'ok' | 'cancel'
+        self._click_targets: list[tuple[int, int, int, str]] = []
 
         # Initialize bit states
         self._bit_states: dict[str, TriState] = {}
@@ -1182,6 +1195,11 @@ class ChmodDialog:
     def handle_key(self, key: int) -> int | None:
         """Handle a keypress.
 
+        Returns the resulting mode int when OK is activated, None
+        otherwise (continuing or cancelled). Also calls
+        :meth:`Modal.set_result` so the inherited :meth:`Modal.show` loop
+        terminates correctly.
+
         Args:
             key: Key code from curses.
 
@@ -1193,6 +1211,7 @@ class ChmodDialog:
         # Escape cancels
         if key == 27:
             self.cancelled = True
+            self.set_result(None)
             return None
 
         # Navigation
@@ -1245,9 +1264,12 @@ class ChmodDialog:
         elif key in (curses.KEY_ENTER, ord('\n'), ord('\r')):
             if self.focus_section == 'buttons':
                 if self.button_focus == 0:  # OK
-                    return self.get_result_mode()
+                    mode = self.get_result_mode()
+                    self.set_result(mode)
+                    return mode
                 else:  # Cancel
                     self.cancelled = True
+                    self.set_result(None)
                     return None
             else:
                 # Enter on checkbox toggles it
@@ -1273,6 +1295,43 @@ class ChmodDialog:
                 self.focus_section = 'grid'
 
         return None  # Continue dialog
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        """Click on any registered hit region: toggle / activate (#16)."""
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        for x_start, x_end, target_y, action_id in self._click_targets:
+            if y == target_y and x_start <= x < x_end:
+                self._activate_action(action_id)
+                return
+
+    def _activate_action(self, action_id: str) -> None:
+        """Apply the side effect of clicking the given hit region."""
+        if action_id == 'ok':
+            mode = self.get_result_mode()
+            self.set_result(mode)
+            return
+        if action_id == 'cancel':
+            self.cancelled = True
+            self.set_result(None)
+            return
+        if action_id == 'recursive':
+            self.focus_section = 'recursive'
+            self.toggle_recursive()
+            return
+        if action_id.startswith('grid:'):
+            _, row, col = action_id.split(':')
+            self.focus_section = 'grid'
+            self.cursor_row = int(row)
+            self.cursor_col = int(col)
+            self.toggle_current()
+            return
+        if action_id.startswith('special:'):
+            _, col = action_id.split(':')
+            self.focus_section = 'special'
+            self.cursor_col = int(col)
+            self.toggle_current()
+            return
 
     def get_result_mode(self) -> int:
         """Calculate mode from current bit states.
@@ -1328,6 +1387,9 @@ class ChmodDialog:
         dialog_attr = get_attr(PAIR_DIALOG)
         title_attr = get_attr(PAIR_DIALOG_TITLE)
 
+        # Reset click hit-regions; populated as we render each focusable element.
+        self._click_targets.clear()
+
         # Draw border and title
         title = 'Change Permissions'
         top_border = '┌─ ' + title + ' ' + '─' * (width - len(title) - 5) + '┐'
@@ -1355,7 +1417,14 @@ class ChmodDialog:
         self._draw_line(win, line_y, start_x, width, header, dialog_attr)
         line_y += 1
 
-        # Permission grid
+        # Permission grid. Each cell has the layout
+        #   [2-space pad][label 6][col0 9-char chunk][col1 9-char chunk][col2]
+        # where each col chunk is "  <5-char-checkbox>  ". The line itself is
+        # prefixed by '│ ' (2 chars) inside the start_x offset (see _draw_line).
+        # So col_idx N's checkbox visible region starts at:
+        #   start_x + 2 (border) + 2 (pad) + 6 (label) + N*9 + 2 (chunk pad) + 1 (>/space)
+        # = start_x + 13 + N*9. The clickable bracketed checkbox is 5 chars
+        # ('>[x]<' or ' [x] ').
         row_labels = ['Owner', 'Group', 'Other']
         for row_idx, label in enumerate(row_labels):
             row_text = f'  {label:6}'
@@ -1374,6 +1443,12 @@ class ChmodDialog:
 
                 row_text += f'  {checkbox}  '
 
+                # Record click hit region (the visible 5-char checkbox span).
+                cb_x = start_x + 13 + col_idx * 9
+                self._click_targets.append(
+                    (cb_x, cb_x + 5, line_y, f'grid:{row_idx}:{col_idx}')
+                )
+
             self._draw_line(win, line_y, start_x, width, row_text, dialog_attr)
             line_y += 1
 
@@ -1381,7 +1456,12 @@ class ChmodDialog:
         self._draw_line(win, line_y, start_x, width, '', dialog_attr)
         line_y += 1
 
-        # Special bits row
+        # Special bits row. Layout:
+        #   '  Special:' (10 chars) then per-column 14 chars:
+        #       focused:    '  >[x]< Set UID' (15-char-ish; actually 2 pad + 5 cb + 1 sp + 7 label = 15)
+        #       unfocused:  '   [x]  Set UID' (3 pad + 3 cb + 2 pad + 7 label = 15)
+        # We track checkbox span = 5 chars (the bracketed cell).
+        # column_x = start_x + 2 (border) + 10 (label) + col_idx * 15 + 2 (pad)
         special_text = '  Special:'
         special_labels = ['Set UID', 'Set GID', 'Sticky']
         for col_idx, (bit_name, label) in enumerate(zip(_SPECIAL_BITS, special_labels)):
@@ -1392,6 +1472,11 @@ class ChmodDialog:
                 special_text += f'  >{checkbox}< {label}'
             else:
                 special_text += f'   {checkbox}  {label}'
+
+            cb_x = start_x + 12 + col_idx * 15
+            self._click_targets.append(
+                (cb_x, cb_x + 5, line_y, f'special:{col_idx}')
+            )
 
         self._draw_line(win, line_y, start_x, width, special_text, dialog_attr)
         line_y += 1
@@ -1405,7 +1490,10 @@ class ChmodDialog:
         self._draw_line(win, line_y, start_x, width, f'  Mode: {octal}', dialog_attr)
         line_y += 1
 
-        # Recursive option (only for directories)
+        # Recursive option (only for directories). Layout matches Special:
+        #   focused:    '  >[x]< Apply recursively'  (cb at offset 2)
+        #   unfocused:  '   [x]  Apply recursively'  (cb at offset 3)
+        # cb hit-region anchors at start_x + 4 (border 2 + pad 2) and is 5 wide.
         if self.has_directory:
             self._draw_line(win, line_y, start_x, width, '', dialog_attr)
             line_y += 1
@@ -1415,6 +1503,9 @@ class ChmodDialog:
                 recursive_text = f'  >{checkbox}< Apply recursively'
             else:
                 recursive_text = f'   {checkbox}  Apply recursively'
+            self._click_targets.append(
+                (start_x + 4, start_x + 9, line_y, 'recursive')
+            )
             self._draw_line(win, line_y, start_x, width, recursive_text, dialog_attr)
             line_y += 1
 
@@ -1422,11 +1513,23 @@ class ChmodDialog:
         self._draw_line(win, line_y, start_x, width, '', dialog_attr)
         line_y += 1
 
-        # Buttons
+        # Buttons. The full button text is centered within (width - 4) chars.
         ok_btn = '[  OK  ]' if self.focus_section != 'buttons' or self.button_focus != 0 else '[ >OK< ]'
         cancel_btn = '[Cancel]' if self.focus_section != 'buttons' or self.button_focus != 1 else '[>Cancel<]'
-        buttons = f'{ok_btn}  {cancel_btn}'.center(width - 4)
+        button_pair = f'{ok_btn}  {cancel_btn}'
+        buttons = button_pair.center(width - 4)
         self._draw_line(win, line_y, start_x, width, buttons, dialog_attr)
+
+        # Compute button hit-regions from the centered string. _draw_line
+        # adds '│ ' (2-char prefix) at start_x, so the centered text starts
+        # at start_x + 2 + leading_padding.
+        leading_pad = (width - 4 - len(button_pair)) // 2
+        ok_x_start = start_x + 2 + leading_pad
+        ok_x_end = ok_x_start + len(ok_btn)
+        cancel_x_start = ok_x_end + 2  # 2 spaces between buttons
+        cancel_x_end = cancel_x_start + len(cancel_btn)
+        self._click_targets.append((ok_x_start, ok_x_end, line_y, 'ok'))
+        self._click_targets.append((cancel_x_start, cancel_x_end, line_y, 'cancel'))
         line_y += 1
 
         # Bottom border
@@ -1456,26 +1559,8 @@ class ChmodDialog:
         else:
             return '[ ]'
 
-    def show(self, win: Any) -> int | None:
-        """Show dialog and handle input until done.
-
-        Args:
-            win: Curses window.
-
-        Returns:
-            New mode (int) or None if cancelled.
-        """
-        while True:
-            self.render(win)
-            key = win.getch()
-            result = self.handle_key(key)
-
-            if result is not None:
-                return result
-
-            # Check if cancelled (Escape or Cancel button)
-            if self.cancelled:
-                return None
+    # show() inherited from Modal; the loop drives render → getch → handle_key
+    # / handle_click and terminates when set_result fires.
 
 
 def chmod_dialog(

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -296,6 +296,93 @@ def confirm_dialog(
     return ConfirmModal(title, message, default_yes=default_yes).show(win)
 
 
+class OverwriteModal(Modal):
+    """File-already-exists overwrite prompt with mouse and arrow-key nav.
+
+    Five focusable buttons (Yes, No, All, Skip, Older). Esc cancels with
+    OverwriteChoice.CANCEL. Letter shortcuts y/n/a/s/o still work.
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        source_size: int,
+        dest_size: int,
+        source_mtime: float,
+        dest_mtime: float,
+        current: int,
+        total: int,
+    ) -> None:
+        super().__init__()
+        self.title = f'File already exists - {current} of {total}'
+        self.filename = filename
+        self.source_info = (
+            f'Source:  {format_size(source_size):>10}   {format_time(source_mtime)}'
+        )
+        self.dest_info = (
+            f'Dest:    {format_size(dest_size):>10}   {format_time(dest_mtime)}'
+        )
+        self.button_bar = ButtonBar(
+            buttons=[
+                Button(label='Yes', shortcut='y', value=OverwriteChoice.YES),
+                Button(label='No', shortcut='n', value=OverwriteChoice.NO),
+                Button(label='All', shortcut='a', value=OverwriteChoice.YES_ALL),
+                Button(label='Skip', shortcut='s', value=OverwriteChoice.NO_ALL),
+                Button(label='Older', shortcut='o', value=OverwriteChoice.YES_OLDER),
+            ],
+            focused=0,
+        )
+        # Width must fit the title, the filename, file info rows, and the
+        # 5-button bar. The bar needs ~9 cells per button (`[ Older ]` is
+        # the widest button text) — keep the heuristic explicit.
+        min_button_bar_width = len(self.button_bar.buttons) * 9
+        self._width = max(
+            len(self.title) + 6,
+            len(filename) + 6,
+            len(self.source_info) + 6,
+            min_button_bar_width + 4,
+            50,
+        )
+
+    def render(self, win: Any) -> None:
+        body = [self.filename, '', self.source_info, self.dest_info, '']
+        box_y, box_x = draw_modal(win, self.title, body, width=self._width)
+        btn_y = box_y + 3 + len(body) - 1
+        self.button_bar.render(
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+        )
+        win.refresh()
+
+    def handle_key(self, key: int) -> None:
+        if key == 27:  # Escape
+            self.set_result(OverwriteChoice.CANCEL)
+            return
+        # Letter shortcuts (case-insensitive).
+        try:
+            ch = chr(key)
+        except ValueError:
+            ch = ''
+        shortcut_value = self.button_bar.activate_by_shortcut(ch)
+        if shortcut_value is not None:
+            self.set_result(shortcut_value)
+            return
+        if key in (curses.KEY_LEFT, curses.KEY_UP):
+            self.button_bar.move_focus(-1)
+            return
+        if key in (curses.KEY_RIGHT, curses.KEY_DOWN, ord('\t')):
+            self.button_bar.move_focus(1)
+            return
+        if key in (ord('\n'), ord('\r'), curses.KEY_ENTER):
+            self.set_result(self.button_bar.activate())
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        value = self.button_bar.hit_test(x, y)
+        if value is not None:
+            self.set_result(value)
+
+
 def overwrite_dialog(
     win: Any,
     filename: str,
@@ -306,7 +393,9 @@ def overwrite_dialog(
     current: int,
     total: int
 ) -> OverwriteChoice:
-    """Show overwrite confirmation dialog with file details.
+    """Show overwrite confirmation dialog (mouse + keyboard).
+
+    Backed by :class:`OverwriteModal`. See class docstring for behaviour.
 
     Args:
         win: Curses window to draw on.
@@ -321,46 +410,15 @@ def overwrite_dialog(
     Returns:
         User's choice as OverwriteChoice enum.
     """
-    title = f'File already exists - {current} of {total}'
-
-    # Format file info
-    source_info = f'Source:  {format_size(source_size):>10}   {format_time(source_mtime)}'
-    dest_info = f'Dest:    {format_size(dest_size):>10}   {format_time(dest_mtime)}'
-
-    lines = [
-        filename,
-        '',
-        source_info,
-        dest_info,
-    ]
-
-    footer = '(y)es (n)o (a)ll (s)kip-all (o)nly-newer Esc'
-
-    # Calculate width to fit content
-    width = max(
-        len(title) + 6,
-        len(filename) + 6,
-        len(source_info) + 6,
-        len(footer) + 6,
-        50
-    )
-
-    draw_modal(win, title, lines, width=width, footer=footer)
-
-    while True:
-        key = win.getch()
-        if key in (ord('y'), ord('Y')):
-            return OverwriteChoice.YES
-        elif key in (ord('n'), ord('N')):
-            return OverwriteChoice.NO
-        elif key in (ord('a'), ord('A')):
-            return OverwriteChoice.YES_ALL
-        elif key in (ord('s'), ord('S')):
-            return OverwriteChoice.NO_ALL
-        elif key in (ord('o'), ord('O')):
-            return OverwriteChoice.YES_OLDER
-        elif key == 27:  # Escape
-            return OverwriteChoice.CANCEL
+    return OverwriteModal(
+        filename=filename,
+        source_size=source_size,
+        dest_size=dest_size,
+        source_mtime=source_mtime,
+        dest_mtime=dest_mtime,
+        current=current,
+        total=total,
+    ).show(win)
 
 
 def show_summary(

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -421,6 +421,43 @@ def overwrite_dialog(
     ).show(win)
 
 
+class SummaryModal(Modal):
+    """Bottom-line success summary with mouse-on-message-row dismiss.
+
+    Renders one line at the bottom of the screen (preserving the previous
+    visual — no centered box, no border) and accepts any keypress to
+    dismiss. Issue #16: a left-click anywhere on the message row also
+    dismisses; clicks elsewhere are ignored.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self.message = message
+        self._last_row = -1  # set during render
+
+    def render(self, win: Any) -> None:
+        rows, cols = win.getmaxyx()
+        self._last_row = rows - 1
+        safe_addstr(win, self._last_row, 0, self.message[: cols - 1])
+        try:
+            win.clrtoeol()
+            win.refresh()
+        except curses.error:
+            pass
+
+    def handle_key(self, key: int) -> None:
+        # Any key dismisses — back-compat with the previous one-line summary.
+        self.set_result(None)
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        # Only the bottom message row dismisses; clicks on the panels above
+        # are ignored so users can keep navigating without losing the summary.
+        if y == self._last_row:
+            self.set_result(None)
+
+
 def show_summary(
     win: Any,
     operation: str,
@@ -432,6 +469,10 @@ def show_summary(
     max_errors: int = 3
 ) -> None:
     """Show operation summary, optionally with error details.
+
+    With errors → centered :class:`ErrorModal` (mouse + keyboard).
+    Without errors → bottom-row :class:`SummaryModal` (any key or click on
+    the message row dismisses).
 
     Args:
         win: Curses window to draw on.
@@ -468,9 +509,6 @@ def show_summary(
         return
 
     # No errors - show simple message at bottom
-    rows, cols = win.getmaxyx()
-    last_row = rows - 1
-
     if cancelled:
         message = 'Operation cancelled'
     elif operation == 'copy':
@@ -486,14 +524,7 @@ def show_summary(
 
     message += ' [Press any key]'
 
-    safe_addstr(win, last_row, 0, message[:cols - 1])
-    try:
-        win.clrtoeol()
-        win.refresh()
-    except curses.error:
-        pass
-
-    win.getch()
+    SummaryModal(message).show(win)
 
 
 class ErrorModal(Modal):

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from tnc.colors import PAIR_DIALOG, PAIR_DIALOG_TITLE, get_attr
 from tnc.file_ops import OverwriteChoice, OverwriteHandler
+from tnc.modal import Button, ButtonBar, Modal
 from tnc.utils import format_size, safe_addstr
 
 
@@ -210,13 +211,78 @@ def draw_modal(
     return (y, x)
 
 
+class ConfirmModal(Modal):
+    """Y/N confirmation dialog backed by the shared Modal shell.
+
+    Click on either button activates it; arrow keys cycle focus; Enter
+    activates the focused button. The original y/n/Esc/Enter shortcuts
+    are preserved for muscle memory.
+    """
+
+    def __init__(
+        self, title: str, message: str, default_yes: bool = True
+    ) -> None:
+        super().__init__()
+        self.title = title
+        self.message = message
+        self.default_yes = default_yes
+        self.button_bar = ButtonBar(
+            buttons=[
+                Button(label='Yes', shortcut='y', value=True),
+                Button(label='No', shortcut='n', value=False),
+            ],
+            focused=0 if default_yes else 1,
+        )
+        self._width = max(len(message) + 6, len(title) + 6, 30)
+
+    def render(self, win: Any) -> None:
+        # Reserve one body line for the button bar (rendered on top).
+        body = [self.message, '', '']
+        box_y, box_x = draw_modal(win, self.title, body, width=self._width)
+        btn_y = box_y + 3 + len(body) - 1
+        self.button_bar.render(
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+        )
+        win.refresh()
+
+    def handle_key(self, key: int) -> None:
+        # Letter shortcuts (case-insensitive).
+        if key in (ord('y'), ord('Y')):
+            self.set_result(True)
+            return
+        if key in (ord('n'), ord('N'), 27):  # 27 = Escape
+            self.set_result(False)
+            return
+        # Arrow / Tab → cycle focus.
+        if key in (curses.KEY_LEFT, curses.KEY_UP):
+            self.button_bar.move_focus(-1)
+            return
+        if key in (curses.KEY_RIGHT, curses.KEY_DOWN, ord('\t')):
+            self.button_bar.move_focus(1)
+            return
+        # Enter activates the focused button.
+        if key in (ord('\n'), ord('\r'), curses.KEY_ENTER):
+            self.set_result(self.button_bar.activate())
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        value = self.button_bar.hit_test(x, y)
+        if value is not None:
+            self.set_result(value)
+
+
 def confirm_dialog(
     win: Any,
     title: str,
     message: str,
     default_yes: bool = True
 ) -> bool:
-    """Show a simple y/n confirmation dialog.
+    """Show a simple y/n confirmation dialog (mouse + keyboard).
+
+    Backed by :class:`ConfirmModal`. Mouse click on either button activates
+    it; arrow keys / Tab cycle focus; Enter activates the focused button;
+    y/n/Esc keep their original meaning for muscle memory.
 
     Args:
         win: Curses window to draw on.
@@ -227,23 +293,7 @@ def confirm_dialog(
     Returns:
         True if user confirmed, False otherwise.
     """
-    # Show [Y/n] or [y/N] based on default
-    if default_yes:
-        hint = '[Y/n]'
-    else:
-        hint = '[y/N]'
-
-    lines = [message, '', f'(y)es  (n)o  {hint}']
-    draw_modal(win, title, lines, width=max(len(message) + 6, len(title) + 6, 30))
-
-    while True:
-        key = win.getch()
-        if key in (ord('y'), ord('Y')):
-            return True
-        elif key in (ord('n'), ord('N'), 27):  # 27 = Escape
-            return False
-        elif key in (ord('\n'), ord('\r'), curses.KEY_ENTER):
-            return default_yes
+    return ConfirmModal(title, message, default_yes=default_yes).show(win)
 
 
 def overwrite_dialog(

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -496,6 +496,69 @@ def show_summary(
     win.getch()
 
 
+class ErrorModal(Modal):
+    """Modal error dialog with mouse + keyboard dismiss.
+
+    Click on OK or press any key to dismiss. Esc also dismisses (cancel and
+    OK behave identically — there's nothing else to do). The "any key" path
+    preserves muscle memory and the dozens of existing tests that stub
+    ``getch.return_value = ord('q')``.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        details: list[str] | None = None,
+        max_details: int = 5,
+    ) -> None:
+        super().__init__()
+        self.title = title
+
+        lines = [message, '']
+        if details:
+            for error in details[:max_details]:
+                lines.append(f'  {error}')
+            remaining = len(details) - max_details
+            if remaining > 0:
+                lines.append(f'  ...and {remaining} more error(s)')
+        lines.append('')
+
+        self._body = lines
+        self.button_bar = ButtonBar(
+            buttons=[Button(label='OK', shortcut='', value=None)],
+            focused=0,
+        )
+
+        max_line_len = max(len(line) for line in lines + [self.title]) if lines else len(self.title)
+        self._width = max(len(self.title) + 6, max_line_len + 6, 40)
+
+    def render(self, win: Any) -> None:
+        body = self._body + ['']  # last line reserved for button bar
+        box_y, box_x = draw_modal(win, self.title, body, width=self._width)
+        btn_y = box_y + 3 + len(body) - 1
+        self.button_bar.render(
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4
+        )
+        win.refresh()
+
+    def handle_key(self, key: int) -> None:
+        # Any key dismisses — back-compat with the previous "press any key"
+        # contract. set_result(None) signals a clean dismiss.
+        self.set_result(None)
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        # The OK button's value is None (there's no other meaningful return),
+        # so ButtonBar.hit_test can't tell "hit OK" from "missed". Walk the
+        # cached positions explicitly: in-bar click dismisses, outside ignores.
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        for x_start, x_end, btn_y, _value in self.button_bar.button_positions:
+            if y == btn_y and x_start <= x < x_end:
+                self.set_result(None)
+                return
+
+
 def show_error_dialog(
     win: Any,
     title: str,
@@ -503,11 +566,11 @@ def show_error_dialog(
     details: list[str] | None = None,
     max_details: int = 5
 ) -> None:
-    """Display a modal error dialog.
+    """Display a modal error dialog (mouse + keyboard).
 
     Shows an error message in a centered modal dialog, optionally with
-    additional detail lines (e.g., per-file errors). Waits for user to
-    press any key before returning.
+    additional detail lines (e.g., per-file errors). Click OK or press any
+    key to dismiss.
 
     Args:
         win: Curses window to draw on.
@@ -516,27 +579,7 @@ def show_error_dialog(
         details: Optional list of detailed error messages (e.g., per-file errors).
         max_details: Maximum number of detail lines to show before truncating.
     """
-    lines = [message, '']
-
-    if details:
-        # Show up to max_details errors
-        for error in details[:max_details]:
-            lines.append(f'  {error}')
-
-        # Show truncation message if there are more
-        remaining = len(details) - max_details
-        if remaining > 0:
-            lines.append(f'  ...and {remaining} more error(s)')
-
-    lines.append('')
-    lines.append('[Press any key]')
-
-    # Calculate width to fit content
-    max_line_len = max(len(line) for line in lines)
-    width = max(len(title) + 6, max_line_len + 6, 40)
-
-    draw_modal(win, title, lines, width=width)
-    win.getch()
+    ErrorModal(title, message, details=details, max_details=max_details).show(win)
 
 
 class CursesOverwriteHandler(OverwriteHandler):

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -739,16 +739,23 @@ class CursesDialogProvider:
         return input_dialog(self.win, title, prompt, default_value)
 
 
-class SelectionDialog:
+class SelectionDialog(Modal):
     """A modal selection dialog with numbered options.
 
     Displays a centered, bordered dialog box with a title and
     numbered options. Optionally includes a Custom option for text input.
 
+    Issue #16: subclasses :class:`Modal` so it inherits mouse routing.
+    Up/Down arrows move focus across options; Enter activates focused;
+    digit shortcuts (1-9) and Esc behaviour are preserved. Click on an
+    option activates it directly.
+
     Attributes:
         title: Dialog title displayed in top border.
         options: List of option strings.
         allow_custom: Whether to show Custom option.
+        focused: Index of the currently focused option (0-indexed across
+            real options + Custom slot if enabled).
         in_custom_input_mode: Whether currently in text input mode.
         custom_text: Text entered in custom mode.
     """
@@ -768,11 +775,15 @@ class SelectionDialog:
             options: List of options to display.
             allow_custom: If True, add Custom option for text input.
         """
+        super().__init__()
         self.title = title
         self.options = options
         self.allow_custom = allow_custom
         self.in_custom_input_mode = False
         self.custom_text = ''
+        self.focused = 0
+        # Each entry: (x_start, x_end, y, option_index_or_'custom')
+        self.option_positions: list[tuple[int, int, int, Any]] = []
 
     def get_dimensions(self) -> tuple[int, int]:
         """Calculate dialog dimensions based on content.
@@ -802,31 +813,61 @@ class SelectionDialog:
 
         return width, height
 
+    def _total_focusable(self) -> int:
+        """Count of focusable rows (real options + Custom if enabled)."""
+        return len(self.options) + (1 if self.allow_custom else 0)
+
     def handle_key(self, key: int) -> str | None:
-        """Handle a keypress and return result.
+        """Handle a keypress.
+
+        Returns the selected string for direct callers (back-compat with
+        existing tests). Internally also calls :meth:`Modal.set_result` so
+        the :meth:`Modal.show` loop terminates correctly.
 
         Args:
             key: Key code from curses.
 
         Returns:
-            Selected option string, or None if not handled/cancelled.
+            Selected option string, or None if not handled / cancelled.
         """
         if self.in_custom_input_mode:
-            return self._handle_custom_input_key(key)
+            result = self._handle_custom_input_key(key)
+            if result is not None:
+                self.set_result(result)
+            return result
 
-        # Escape cancels
+        # Escape cancels.
         if key == 27:
+            self.set_result(None)
             return None
 
-        # Check for number key (supports 1-9 only)
+        # Up/Down move focus across the focusable rows.
+        if key == curses.KEY_UP:
+            total = self._total_focusable()
+            if total > 0:
+                self.focused = (self.focused - 1) % total
+            return None
+        if key == curses.KEY_DOWN:
+            total = self._total_focusable()
+            if total > 0:
+                self.focused = (self.focused + 1) % total
+            return None
+
+        # Enter activates the focused option (new in #16).
+        if key in (ord('\n'), ord('\r'), curses.KEY_ENTER):
+            return self._activate_focused()
+
+        # Digit shortcuts (1-9) — preserve existing behavior.
         try:
             char = chr(key)
             if char.isdigit():
                 num = int(char)
                 if 1 <= num <= len(self.options):
-                    return self.options[num - 1]
+                    result = self.options[num - 1]
+                    self.set_result(result)
+                    return result
                 elif self.allow_custom and num == len(self.options) + 1:
-                    # Enter custom input mode
+                    # Enter custom input mode (no set_result yet).
                     self.in_custom_input_mode = True
                     self.custom_text = ''
                     return None
@@ -834,6 +875,38 @@ class SelectionDialog:
             pass
 
         return None
+
+    def _activate_focused(self) -> str | None:
+        """Activate whatever the focus indicator is currently on."""
+        if self.focused < len(self.options):
+            result = self.options[self.focused]
+            self.set_result(result)
+            return result
+        # Focus on Custom slot.
+        if self.allow_custom and self.focused == len(self.options):
+            self.in_custom_input_mode = True
+            self.custom_text = ''
+            return None
+        return None
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        """Click on a list item activates it (or enters Custom mode)."""
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        if self.in_custom_input_mode:
+            # No clickable widgets in custom-input mode (v1).
+            return
+        for x_start, x_end, row_y, target in self.option_positions:
+            if y == row_y and x_start <= x < x_end:
+                if target == 'custom':
+                    self.focused = len(self.options)
+                    self.in_custom_input_mode = True
+                    self.custom_text = ''
+                    return
+                # `target` is the 0-based option index.
+                self.focused = target
+                self.set_result(self.options[target])
+                return
 
     def _handle_custom_input_key(self, key: int) -> str | None:
         """Handle key in custom input mode.
@@ -905,6 +978,7 @@ class SelectionDialog:
     ) -> None:
         """Render the selection list mode."""
         frame = _render_dialog_frame(width, self.title)
+        self.option_positions.clear()
 
         # Top border
         safe_addstr(stdscr, start_y, start_x, frame['top'], dialog_attr)
@@ -917,18 +991,29 @@ class SelectionDialog:
         # Separator
         safe_addstr(stdscr, start_y + 2, start_x, frame['separator'], dialog_attr)
 
-        # Options
+        # Options. Highlight the focused row with A_REVERSE so keyboard
+        # arrow navigation has a visible cursor (issue #16).
         line_y = start_y + 3
         for i, opt in enumerate(self.options, 1):
             content = f'│  {i}. {opt}'.ljust(width - 1) + '│'
-            safe_addstr(stdscr, line_y, start_x, content, dialog_attr)
+            attr = dialog_attr | (curses.A_REVERSE if self.focused == i - 1 else 0)
+            safe_addstr(stdscr, line_y, start_x, content, attr)
+            self.option_positions.append(
+                (start_x + 1, start_x + width - 1, line_y, i - 1)
+            )
             line_y += 1
 
         # Custom option
         if self.allow_custom:
             num = len(self.options) + 1
             content = f'│  {num}. Custom...'.ljust(width - 1) + '│'
-            safe_addstr(stdscr, line_y, start_x, content, dialog_attr)
+            attr = dialog_attr | (
+                curses.A_REVERSE if self.focused == len(self.options) else 0
+            )
+            safe_addstr(stdscr, line_y, start_x, content, attr)
+            self.option_positions.append(
+                (start_x + 1, start_x + width - 1, line_y, 'custom')
+            )
             line_y += 1
 
         # Empty line
@@ -937,7 +1022,7 @@ class SelectionDialog:
 
         # Hint line
         max_num = len(self.options) + (1 if self.allow_custom else 0)
-        hint = f'Press 1-{max_num} or [Esc] to cancel'
+        hint = f'1-{max_num}, arrows + Enter, or click  [Esc] to cancel'
         safe_addstr(stdscr, line_y, start_x, frame['content_line'](hint), dialog_attr)
         line_y += 1
 
@@ -991,28 +1076,8 @@ class SelectionDialog:
 
         stdscr.refresh()
 
-    def show(self, stdscr: Any) -> str | None:
-        """Show the dialog and handle input until a choice is made.
-
-        Args:
-            stdscr: Curses window.
-
-        Returns:
-            Selected option string, or None if cancelled.
-        """
-        while True:
-            self.render(stdscr)
-            key = stdscr.getch()
-            result = self.handle_key(key)
-
-            # In selection mode, None from number keys means continue
-            # But None from Escape means cancel
-            if result is not None:
-                return result
-
-            # Check if we got Escape (key 27) outside custom mode
-            if not self.in_custom_input_mode and key == 27:
-                return None
+    # show() is inherited from Modal; the loop drives render → getch →
+    # handle_key / handle_click and terminates when set_result fires.
 
 
 # Permission bit names in grid order (3 rows x 3 cols)

--- a/tnc/modal.py
+++ b/tnc/modal.py
@@ -63,11 +63,21 @@ class ButtonBar:
         """Paint the bar and record hit regions.
 
         Buttons are evenly spaced across ``total_width`` starting at
-        ``x_start``. The focused button is rendered with
-        ``base_attr | curses.A_REVERSE``; others with ``base_attr``. Pass
-        the surrounding dialog's color pair as ``base_attr`` so the
-        unfocused buttons blend with the dialog background and the
-        focused one stands out via inverse video on the same palette.
+        ``x_start``.
+
+        Focus indication uses two redundant cues so it's obvious on every
+        terminal regardless of palette or accessibility settings:
+
+        - **Bracket markers** (mc-style): focused buttons render as
+          ``[< Yes >]`` while unfocused render as ``[  Yes  ]``. Both
+          variants are the same width, so the bar layout doesn't shift
+          when focus moves. This works on monochrome terminals and is
+          robust to colorblindness.
+        - **Inverse video**: the focused button is also drawn with
+          ``base_attr | curses.A_REVERSE``; unfocused gets ``base_attr``.
+          Pass the surrounding dialog's color pair as ``base_attr`` so
+          unfocused buttons blend with the dialog background and the
+          focused one stands out via reverse video on the same palette.
         """
         self.button_positions.clear()
         if not self.buttons:
@@ -76,11 +86,16 @@ class ButtonBar:
         slot_width = max(total_width // len(self.buttons), 1)
         for i, btn in enumerate(self.buttons):
             slot_x = x_start + i * slot_width
-            text = f'[ {btn.label} ]'
-            # Center the bracketed label inside the slot.
+            is_focused = i == self.focused
+            # Both variants are the same width: 7 surrounding chars plus
+            # the label, so focus changes don't shift the bar layout.
+            if is_focused:
+                text = f'[< {btn.label} >]'
+            else:
+                text = f'[  {btn.label}  ]'
             offset = max(0, (slot_width - len(text)) // 2)
             text_x = slot_x + offset
-            attr = base_attr | curses.A_REVERSE if i == self.focused else base_attr
+            attr = base_attr | curses.A_REVERSE if is_focused else base_attr
             safe_addstr(win, y, text_x, text, attr)
 
             # Record click region as the visible bracket span.

--- a/tnc/modal.py
+++ b/tnc/modal.py
@@ -1,0 +1,170 @@
+"""Modal base class and ButtonBar widget.
+
+Issue #16: every modal in the app needs mouse and arrow-key navigation. Rather
+than wiring the same input loop into eight different dialogs, this module
+hosts the shared shell. Each modal subclasses :class:`Modal`, overrides
+``render`` and ``handle_key``, and (optionally) ``handle_click``. The base
+owns the ``while True: getch()`` loop and the ``KEY_MOUSE`` → ``getmouse()``
+→ ``handle_click(x, y, button_state)`` routing.
+
+Simple button-style dialogs (Confirm, Overwrite, Error, Summary) compose a
+:class:`ButtonBar` widget for their action buttons. The widget tracks where
+each button was last rendered so click hit-testing is a list lookup.
+"""
+
+from __future__ import annotations
+
+import curses
+from typing import Any, NamedTuple
+
+from tnc.utils import safe_addstr
+
+
+class Button(NamedTuple):
+    """One actionable button inside a :class:`ButtonBar`.
+
+    Attributes:
+        label: Text shown on the button (e.g. ``'Yes'``).
+        shortcut: Single character that activates this button when typed at
+            the keyboard, or empty string for "no shortcut". Case-insensitive.
+        value: Value returned by the button bar when this button is
+            activated.
+    """
+
+    label: str
+    shortcut: str
+    value: Any
+
+
+class ButtonBar:
+    """A horizontal row of focusable buttons.
+
+    Owns its focus state and the post-render hit-region cache. The cache is
+    populated each time :meth:`render` runs so click hit-testing always
+    matches the most recent paint.
+    """
+
+    def __init__(self, buttons: list[Button], focused: int = 0) -> None:
+        if not buttons:
+            raise ValueError('ButtonBar requires at least one button')
+        self.buttons = buttons
+        self.focused = focused
+        # Each entry is (x_start, x_end, y, value); x range is half-open.
+        self.button_positions: list[tuple[int, int, int, Any]] = []
+
+    def render(self, win: Any, y: int, x_start: int, total_width: int) -> None:
+        """Paint the bar and record hit regions.
+
+        Buttons are evenly spaced across ``total_width`` starting at
+        ``x_start``. The focused button is rendered with ``curses.A_REVERSE``;
+        others with ``curses.A_NORMAL``.
+        """
+        self.button_positions.clear()
+        if not self.buttons:
+            return
+
+        slot_width = max(total_width // len(self.buttons), 1)
+        for i, btn in enumerate(self.buttons):
+            slot_x = x_start + i * slot_width
+            text = f'[ {btn.label} ]'
+            # Center the bracketed label inside the slot.
+            offset = max(0, (slot_width - len(text)) // 2)
+            text_x = slot_x + offset
+            attr = curses.A_REVERSE if i == self.focused else curses.A_NORMAL
+            safe_addstr(win, y, text_x, text, attr)
+
+            # Record click region as the visible bracket span.
+            self.button_positions.append(
+                (text_x, text_x + len(text), y, btn.value)
+            )
+
+    def hit_test(self, x: int, y: int) -> Any | None:
+        """Return the value of the button at (x, y), or None if outside.
+
+        ``None`` is reserved for "no hit"; callers must avoid using ``None``
+        as a meaningful button value.
+        """
+        for x_start, x_end, btn_y, value in self.button_positions:
+            if y == btn_y and x_start <= x < x_end:
+                return value
+        return None
+
+    def move_focus(self, direction: int) -> None:
+        """Shift focus by ``direction`` (positive = next, negative = prev), wrapping."""
+        n = len(self.buttons)
+        if n == 0:
+            return
+        self.focused = (self.focused + direction) % n
+
+    def activate(self) -> Any:
+        """Return the currently focused button's value."""
+        return self.buttons[self.focused].value
+
+    def activate_by_shortcut(self, ch: str) -> Any | None:
+        """Return the value of the button whose shortcut matches ``ch``.
+
+        Match is case-insensitive. Empty shortcuts never match. Returns
+        ``None`` if no button matches.
+        """
+        if not ch:
+            return None
+        ch_low = ch.lower()
+        for btn in self.buttons:
+            if btn.shortcut and btn.shortcut.lower() == ch_low:
+                return btn.value
+        return None
+
+
+# Sentinel: when ``Modal._result`` holds this object, the modal has not yet
+# resolved a return value. Allows ``None`` and ``False`` to be valid results.
+_UNSET: Any = object()
+
+
+class Modal:
+    """Base class for modal dialogs.
+
+    Subclasses override:
+
+    * ``render(win)`` — paint the modal each iteration of the loop.
+    * ``handle_key(key)`` — react to an integer key code from ``getch``.
+    * ``handle_click(x, y, button_state)`` — react to mouse clicks; default
+      implementation ignores them.
+
+    To finish the modal, the subclass calls :meth:`set_result` with the value
+    that should be returned from :meth:`show`.
+    """
+
+    def __init__(self) -> None:
+        self._done = False
+        self._result: Any = _UNSET
+
+    def set_result(self, value: Any) -> None:
+        """Mark the modal as done and queue ``value`` for return."""
+        self._result = value
+        self._done = True
+
+    def show(self, win: Any) -> Any:
+        """Run the input loop until a subclass sets a result."""
+        while not self._done:
+            self.render(win)
+            key = win.getch()
+            if key == curses.KEY_MOUSE:
+                try:
+                    _, x, y, _, button_state = curses.getmouse()
+                except curses.error:
+                    # Lost-mouse-event — drop and continue rather than crash.
+                    continue
+                self.handle_click(x, y, button_state)
+            else:
+                self.handle_key(key)
+        return self._result
+
+    def render(self, win: Any) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def handle_key(self, key: int) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        """Default: ignore. Subclasses with clickable elements override."""
+        return None

--- a/tnc/modal.py
+++ b/tnc/modal.py
@@ -52,12 +52,22 @@ class ButtonBar:
         # Each entry is (x_start, x_end, y, value); x range is half-open.
         self.button_positions: list[tuple[int, int, int, Any]] = []
 
-    def render(self, win: Any, y: int, x_start: int, total_width: int) -> None:
+    def render(
+        self,
+        win: Any,
+        y: int,
+        x_start: int,
+        total_width: int,
+        base_attr: int = 0,
+    ) -> None:
         """Paint the bar and record hit regions.
 
         Buttons are evenly spaced across ``total_width`` starting at
-        ``x_start``. The focused button is rendered with ``curses.A_REVERSE``;
-        others with ``curses.A_NORMAL``.
+        ``x_start``. The focused button is rendered with
+        ``base_attr | curses.A_REVERSE``; others with ``base_attr``. Pass
+        the surrounding dialog's color pair as ``base_attr`` so the
+        unfocused buttons blend with the dialog background and the
+        focused one stands out via inverse video on the same palette.
         """
         self.button_positions.clear()
         if not self.buttons:
@@ -70,7 +80,7 @@ class ButtonBar:
             # Center the bracketed label inside the slot.
             offset = max(0, (slot_width - len(text)) // 2)
             text_x = slot_x + offset
-            attr = curses.A_REVERSE if i == self.focused else curses.A_NORMAL
+            attr = base_attr | curses.A_REVERSE if i == self.focused else base_attr
             safe_addstr(win, y, text_x, text, attr)
 
             # Record click region as the visible bracket span.


### PR DESCRIPTION
## Summary
- New `tnc/modal.py` with a reusable `Modal` base class and `ButtonBar` widget. The base owns the input loop and routes `KEY_MOUSE → curses.getmouse() → handle_click(x, y, button_state)`. Every modal now gains mouse support by subclassing it.
- All 8 dialogs in `tnc/dialog.py` migrated: `ConfirmModal`, `OverwriteModal`, `ErrorModal`, `SummaryModal`, `SelectionDialog`, `InputDialog`, `ChmodDialog`, `ChownDialog`.
- Public function entry points (`confirm_dialog`, `overwrite_dialog`, `show_summary`, `show_error_dialog`, `input_dialog`, `chmod_dialog`, `chown_dialog`) keep their signatures — they are now thin wrappers around the modal classes, so no call site changes.

## Related Issue
Closes #16

## What changed per dialog

| Modal | New click targets | New keyboard | Preserved |
|---|---|---|---|
| Confirm | Yes / No buttons | ↑↓← → / Tab cycle, Enter activates | y / n / Esc / Enter (default-yes) |
| Overwrite | Yes / No / All / Skip / Older buttons | ↑↓ ← → / Tab cycle, Enter activates | y / n / a / s / o / Esc |
| Error | OK button (outside ignored) | — | any key dismisses |
| Summary | Bottom-row message dismisses; outside ignored | — | any key dismisses |
| Selection | Each option row + Custom row | ↑↓ wrap focus, Enter activates | digits 1-9, Esc, custom-mode editing |
| Input | OK / Cancel buttons; click in field repositions cursor | — | typing, cursor keys, Enter, Esc |
| Chmod | 9 grid checkboxes + 3 special bits + recursive + OK / Cancel | — | full existing arrow + Tab + Space + Enter + Esc |
| Chown | Owner field, group field, OK / Cancel | — | Tab cycle, autocomplete arrows, Enter, Esc |

## Architecture

```
tnc/modal.py
├── class Modal
│   def show(win):
│       while not self._done:
│           self.render(win)
│           key = win.getch()
│           if key == curses.KEY_MOUSE:
│               x, y, btn = curses.getmouse()
│               self.handle_click(x, y, btn)
│           else:
│               self.handle_key(key)
│       return self._result
│   def render(win)              # subclasses override
│   def handle_key(key)          # subclasses override
│   def handle_click(x, y, btn)  # default: ignore
│
└── class ButtonBar
    buttons: list[Button(label, shortcut, value)]
    focused: int
    render(win, y, x_start, total_width)  # records hit-regions
    hit_test(x, y) -> Any | None
    move_focus(direction)
    activate() / activate_by_shortcut(ch)
```

User-confirmed behavior choices:
- **Focus indicator:** terminal `curses.A_REVERSE` on focused button (works on monochrome; matches the panel selection style).
- **Outside-modal clicks:** ignored — no accidental cancels.
- **Letter shortcuts and any-key dismiss preserved** for muscle memory.

For Chmod / Chown the hit regions are recorded as `(x_start, x_end, y, action_id)` tuples each render, with stable action ids (`'grid:0:0'`, `'special:1'`, `'recursive'`, `'ok'`, `'cancel'`, `'owner_field'`, `'group_field'`). Tests look up regions by id rather than hard-coded coordinates, so future layout tweaks don't require test changes.

## Testing Done
- [x] **T1 — Modal base + ButtonBar (RED→GREEN):** 12 new tests in `tests/test_modal.py` — loop driver, mouse routing, dropped getmouse error, set_result termination, focus wrap, hit-test inside / outside / wrong row, A_REVERSE on focused button, shortcut activation. RED → GREEN confirmed by ImportError before implementation.
- [x] **Per-dialog mouse/arrow tests:** new `Test*Mouse` classes in `tests/test_dialog.py` (Confirm, Overwrite, Error, Summary, Selection), `tests/test_input_dialog.py` (Input), `tests/test_chmod_dialog.py` (Chmod), `tests/test_chown_dialog.py` (Chown). Each covers click on every actionable element + a regression test that the original keyboard contract still works.
- [x] **Updated assertion in `tests/test_confirmation_dialog.py`** (delete prompt format): the old `[Y/n]` hint string was replaced by visible `[ Yes ]` / `[ No ]` buttons; the two existing format tests now assert the new bracketed buttons instead.
- [x] **Full suite:** `python3.14 -m unittest discover -s tests` → 1207 ran, only the 4 pre-existing baseline failures (`test_edit_textedit_maps_to_open_e`, three `test_mouse` mock-setup tests) remain. **No new failures.**

## Out of scope (deferred)
- Touch / drag gestures inside dialogs.
- Tab-completion in InputDialog beyond what `pathlib.Path` already does.
- Mouse-wheel scrolling within long modals (e.g., long error lists).
- Hover-only focus.
- A11y audit beyond inverse-video being mono-safe.

## Breaking Changes
None. Public dialog function signatures are unchanged. The renamed inline `[Y/n]` hint in confirm dialogs is the only user-visible visual delta beyond "buttons now exist as clickable widgets" — see `tests/test_confirmation_dialog.py` for the equivalent new assertion.

## Checklist
- [x] Code follows project conventions (zero deps, stdlib only, TDD)
- [x] Tests added (12 new in test_modal.py + 30+ across the dialog test files)
- [x] Documentation updated — none needed; CLAUDE.md doesn't describe modal internals
- [x] No secrets committed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)