### PR TITLE
feat: add F1 Help and F2 Menu to function bar (mc parity, #78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ This is a modern tool for modern systems. If someone is on an older Python, they
 Tab         Switch active panel
 Arrow keys  Navigate
 Enter       Enter directory / open file with $EDITOR
+F1          Help (keybindings dialog)
+F2          Menu bar (alias of F9)
 F3          View file (pager)
 F4          Edit file ($EDITOR)
 F5          Copy

--- a/tests/test_function_bar.py
+++ b/tests/test_function_bar.py
@@ -155,9 +155,9 @@ class TestFunctionBar(unittest.TestCase):
 
         bar.render(mock_win, y=24, width=80)
 
-        # With 8 keys and width=80, cell_width = 80 // 8 = 10
-        cell_width = 80 // 8
-        expected_starts = [i * cell_width for i in range(8)]
+        # Issue #78: bar now has 10 buttons (F1-F10). cell_width = 80 // 10 = 8.
+        cell_width = 80 // 10
+        expected_starts = [i * cell_width for i in range(10)]
         actual_starts = [start_x for start_x, _, _ in bar.button_positions]
         self.assertEqual(actual_starts, expected_starts)
 
@@ -169,8 +169,8 @@ class TestFunctionBar(unittest.TestCase):
 
         bar.render(mock_win, y=24, width=80)
 
-        cell_width = 80 // 8
-        expected_starts = [i * cell_width for i in range(8)]
+        cell_width = 80 // 10
+        expected_starts = [i * cell_width for i in range(10)]
         actual_starts = [start_x for start_x, _, _ in bar.button_positions]
         self.assertEqual(actual_starts, expected_starts)
 

--- a/tests/test_function_bar_mouse.py
+++ b/tests/test_function_bar_mouse.py
@@ -45,8 +45,8 @@ class TestFunctionBarPositionTracking(unittest.TestCase):
 
         bar.render(mock_win, y=23, width=80)
 
-        # Should have positions for all 8 buttons (F3-F10 including F9)
-        self.assertEqual(len(bar.button_positions), 8)
+        # Issue #78 added F1 Help and F2 Menu, so the bar now shows 10 buttons.
+        self.assertEqual(len(bar.button_positions), 10)
 
     def test_button_positions_have_correct_structure(self):
         """Each button position should be (start_x, end_x, action)."""
@@ -71,14 +71,24 @@ class TestFunctionBarPositionTracking(unittest.TestCase):
         bar.render(mock_win, y=23, width=80)
 
         actions = [pos[2] for pos in bar.button_positions]
+        self.assertIn(Action.HELP, actions)  # F1, issue #78
+        self.assertIn(Action.MENU, actions)  # F2 / F9, issue #78
         self.assertIn(Action.VIEW, actions)
         self.assertIn(Action.EDIT, actions)
         self.assertIn(Action.COPY, actions)
         self.assertIn(Action.MOVE, actions)
         self.assertIn(Action.MKDIR, actions)
         self.assertIn(Action.DELETE, actions)
-        self.assertIn(Action.MENU, actions)
         self.assertIn(Action.QUIT, actions)
+
+    def test_button_positions_first_two_cells_are_f1_help_and_f2_menu(self):
+        """Issue #78: F1 (Help) is at cell 0, F2 (Menu) is at cell 1."""
+        bar = FunctionBar()
+        mock_win = mock.MagicMock()
+        bar.render(mock_win, y=23, width=80)
+
+        self.assertEqual(bar.button_positions[0][2], Action.HELP)
+        self.assertEqual(bar.button_positions[1][2], Action.MENU)
 
     def test_render_clears_previous_positions(self):
         """render() should clear previous button_positions."""
@@ -144,21 +154,20 @@ class TestFunctionBarActionAtPoint(unittest.TestCase):
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
-        # With 8 buttons and width=80, cell_width = 10
-        # First button (F3 View) should be at x=0-9
+        # Issue #78: 10 buttons at width=80, cell_width = 8.
+        # First button (F1 Help) covers x=0-7.
         result = bar.action_at_point(5)
         self.assertIsNotNone(result)
         self.assertIsInstance(result, Action)
 
-    def test_action_at_point_first_button_is_view(self):
-        """First button (F3) should return Action.VIEW."""
+    def test_action_at_point_first_button_is_help(self):
+        """First button (F1) should return Action.HELP after issue #78."""
         bar = FunctionBar()
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
-        # First button starts at x=0
         result = bar.action_at_point(0)
-        self.assertEqual(result, Action.VIEW)
+        self.assertEqual(result, Action.HELP)
 
     def test_action_at_point_last_button_is_quit(self):
         """Last button (F10) should return Action.QUIT."""
@@ -166,9 +175,8 @@ class TestFunctionBarActionAtPoint(unittest.TestCase):
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
-        # With 8 buttons and width=80, cell_width = 10
-        # Last button (F10 Quit) at position 7, starts at x=70
-        result = bar.action_at_point(70)
+        # Issue #78: F10 is 10th button (index 9), at x = 9 * 8 = 72.
+        result = bar.action_at_point(72)
         self.assertEqual(result, Action.QUIT)
 
     def test_action_at_point_returns_none_past_buttons(self):
@@ -187,8 +195,8 @@ class TestFunctionBarActionAtPoint(unittest.TestCase):
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
-        # F9 is 7th button (index 6), at x = 6 * 10 = 60
-        result = bar.action_at_point(60)
+        # Issue #78: F9 is 9th button (index 8), at x = 8 * 8 = 64.
+        result = bar.action_at_point(64)
         self.assertEqual(result, Action.MENU)
 
 
@@ -205,11 +213,11 @@ class TestAppHandleMouseFunctionBar(unittest.TestCase):
         app.setup()
         app.draw()
 
-        # Function bar is at last row (y=23)
-        # F3 (View) is first button
+        # Function bar is at last row (y=23). Issue #78: F1 (Help) is the
+        # first button at cell [0, 8).
         result = app.handle_mouse(5, 23, curses.BUTTON1_CLICKED)
 
-        self.assertEqual(result, Action.VIEW)
+        self.assertEqual(result, Action.HELP)
 
     @mock.patch('curses.has_colors', return_value=False)
     @mock.patch('curses.curs_set')
@@ -221,8 +229,8 @@ class TestAppHandleMouseFunctionBar(unittest.TestCase):
         app.setup()
         app.draw()
 
-        # F5 is 3rd button (index 2), at x = 2 * 10 = 20
-        result = app.handle_mouse(25, 23, curses.BUTTON1_CLICKED)
+        # Issue #78: F5 is 5th button (index 4), at x = 4 * 8 = 32.
+        result = app.handle_mouse(33, 23, curses.BUTTON1_CLICKED)
 
         self.assertEqual(result, Action.COPY)
 
@@ -236,7 +244,7 @@ class TestAppHandleMouseFunctionBar(unittest.TestCase):
         app.setup()
         app.draw()
 
-        # F10 is last button (index 7), at x = 7 * 10 = 70
+        # Issue #78: F10 is last button (index 9), at x = 9 * 8 = 72.
         result = app.handle_mouse(75, 23, curses.BUTTON1_CLICKED)
 
         self.assertEqual(result, Action.QUIT)
@@ -251,7 +259,7 @@ class TestAppHandleMouseFunctionBar(unittest.TestCase):
         app.setup()
         app.draw()
 
-        # F9 is 7th button (index 6), at x = 6 * 10 = 60
+        # Issue #78: F9 is 9th button (index 8), at x = 8 * 8 = 64.
         result = app.handle_mouse(65, 23, curses.BUTTON1_CLICKED)
 
         self.assertEqual(result, Action.MENU)
@@ -354,38 +362,26 @@ class TestFunctionBarLabelCentering(unittest.TestCase):
         # spans the full width). Keep only key/label render calls.
         return [(x, t) for (x, t) in calls if not (x == 0 and len(t) == width)]
 
-    def test_label_rendered_centered_within_cell_at_width_80(self):
-        """At width=80 (cell_width=10), F7's ' F7Mkdir' (8 chars) should
-        render centered at x = 40 + (10-8)//2 = 41, not at x = 40."""
-        bar = FunctionBar()
-        calls = self._capture_addstr_calls(bar, width=80)
-
-        # Find the call that wrote ' F7' (the F7 key portion).
-        f7_calls = [(x, t) for (x, t) in calls if t == ' F7']
-        self.assertEqual(len(f7_calls), 1, f'expected 1 ` F7` render, got {f7_calls}')
-        x, _ = f7_calls[0]
-        # Cell is [40, 50). Label ' F7Mkdir' is 8 chars. Centered: 40 + 1 = 41.
-        self.assertEqual(x, 41, f'F7 key should render at x=41 (centered), got x={x}')
-
     def test_label_rendered_centered_within_cell_at_width_145(self):
-        """At width=145 (cell_width=18), F8's ' F8Delete' (9 chars) should
-        render centered at x = 90 + (18-9)//2 = 94, not at x = 90."""
+        """At width=145 (10 buttons after #78, cell_width=14), F7's
+        ' F7Mkdir' (8 chars) should render centered at x = 6*14 + (14-8)//2
+        = 84 + 3 = 87, not at the cell start x=84."""
         bar = FunctionBar()
         calls = self._capture_addstr_calls(bar, width=145)
 
-        f8_calls = [(x, t) for (x, t) in calls if t == ' F8']
-        self.assertEqual(len(f8_calls), 1)
-        x, _ = f8_calls[0]
-        # Cell is [90, 108). Label ' F8Delete' is 9 chars. Centered: 90 + 4 = 94.
-        self.assertEqual(x, 94, f'F8 key should render at x=94 (centered), got x={x}')
+        f7_calls = [(x, t) for (x, t) in calls if t == ' F7']
+        self.assertEqual(len(f7_calls), 1)
+        x, _ = f7_calls[0]
+        # F7 is index 6 in the 10-button bar. Cell [84, 98). Label is 8 chars.
+        self.assertEqual(x, 87, f'F7 key should render at x=87 (centered), got x={x}')
 
     def test_narrow_cell_clamps_label_to_cell_start(self):
         """When the label is wider than the cell, the centering offset
         would go negative. The clamp `max(0, ...)` must keep the label
         starting at start_x, never to the left of it."""
         bar = FunctionBar()
-        calls = self._capture_addstr_calls(bar, width=24)
-        # cell_width = 24 // 8 = 3. Every label is wider than 3.
+        # 10 buttons at width=30 → cell_width=3. Every label is wider than 3.
+        calls = self._capture_addstr_calls(bar, width=30)
         # Each ' F<N>' key render must land at i*3 (no negative shift).
         key_calls = [(x, t) for (x, t) in calls if t.startswith(' F')]
         for i, (x, t) in enumerate(key_calls):
@@ -398,38 +394,36 @@ class TestFunctionBarLabelCentering(unittest.TestCase):
     def test_button_positions_unchanged_by_centering(self):
         """The centering change must NOT alter the click-region table
         (button_positions). Existing keybinding/click logic depends on
-        the same boundaries."""
+        the same boundaries. Issue #78 made the bar 10 buttons wide."""
         bar = FunctionBar()
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
+        # Width=80 → cell_width=8. 10 buttons.
         expected = [
-            (0, 10, Action.VIEW),
-            (10, 20, Action.EDIT),
-            (20, 30, Action.COPY),
-            (30, 40, Action.MOVE),
-            (40, 50, Action.MKDIR),
-            (50, 60, Action.DELETE),
-            (60, 70, Action.MENU),
-            (70, 80, Action.QUIT),
+            (0, 8, Action.HELP),
+            (8, 16, Action.MENU),
+            (16, 24, Action.VIEW),
+            (24, 32, Action.EDIT),
+            (32, 40, Action.COPY),
+            (40, 48, Action.MOVE),
+            (48, 56, Action.MKDIR),
+            (56, 64, Action.DELETE),
+            (64, 72, Action.MENU),
+            (72, 80, Action.QUIT),
         ]
         self.assertEqual(bar.button_positions, expected)
 
-    def test_padding_click_visually_adjacent_to_next_label_resolves_to_next(self):
-        """Issue #18 user-facing assertion: at width=80, after centering
-        the F8 label sits at chars 51-59 with one char of left padding
-        at 50. A click at x=50 (visible left edge of F8 region, in F8
-        cell) returns DELETE. Clicks at 49 still return MKDIR (in F7
-        cell), which is correct because x=49 is now visually closer to
-        F7's centered label than to F8's."""
+    def test_click_in_f8_cell_returns_delete(self):
+        """Issue #18 / #78: at width=80, F8 cell is [56, 64). Click in
+        the middle of the cell (x=60) returns Action.DELETE."""
         bar = FunctionBar()
         mock_win = mock.MagicMock()
         bar.render(mock_win, y=23, width=80)
 
-        # Click on F8's left padding (still inside F8 cell [50, 60)):
-        self.assertEqual(bar.action_at_point(50), Action.DELETE)
-        # Click on visible F8 label center:
-        self.assertEqual(bar.action_at_point(55), Action.DELETE)
+        self.assertEqual(bar.action_at_point(56), Action.DELETE)
+        self.assertEqual(bar.action_at_point(60), Action.DELETE)
+        self.assertEqual(bar.action_at_point(63), Action.DELETE)
 
 
 if __name__ == '__main__':

--- a/tests/test_help_dialog.py
+++ b/tests/test_help_dialog.py
@@ -1,0 +1,126 @@
+"""Tests for the F1 help dialog and F1/F2 keyboard routing (issue #78)."""
+
+import curses
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+
+class TestKeybindings(unittest.TestCase):
+    """F1 / F2 must dispatch to Action.HELP / Action.MENU."""
+
+    def _make_app(self):
+        from tnc.app import App
+        with mock.patch('curses.has_colors', return_value=False), \
+             mock.patch('curses.curs_set'), \
+             mock.patch('curses.mousemask'):
+            stdscr = mock.MagicMock()
+            stdscr.getmaxyx.return_value = (24, 80)
+            stdscr.getch.return_value = ord('q')
+            with tempfile.TemporaryDirectory() as td, \
+                 mock.patch('os.getcwd', return_value=td):
+                app = App(stdscr)
+                app.setup()
+                return app
+
+    def test_action_help_exists_in_enum(self):
+        from tnc.app import Action
+        self.assertTrue(hasattr(Action, 'HELP'))
+
+    def test_f1_routes_to_help_action(self):
+        from tnc.app import Action
+        app = self._make_app()
+        self.assertEqual(app.handle_key(curses.KEY_F1), Action.HELP)
+
+    def test_f2_routes_to_menu_action(self):
+        from tnc.app import Action
+        app = self._make_app()
+        self.assertEqual(app.handle_key(curses.KEY_F2), Action.MENU)
+
+
+class TestHelpModal(unittest.TestCase):
+    """HelpModal renders structured keybinding help and dismisses cleanly."""
+
+    def test_help_modal_renders_known_keybindings(self):
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        modal.render(win)
+        all_text = ' '.join(
+            str(call) for call in win.addstr.call_args_list
+        )
+        # Spot-check a few known keys/labels.
+        self.assertIn('F3', all_text)
+        self.assertIn('View', all_text)
+        self.assertIn('Tab', all_text)
+        self.assertIn('Esc', all_text)
+
+    def test_help_modal_renders_section_headers(self):
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        modal.render(win)
+        all_text = ' '.join(
+            str(call) for call in win.addstr.call_args_list
+        )
+        for header in ('Navigation', 'File operations', 'Selection'):
+            self.assertIn(header, all_text)
+
+    def test_help_modal_dismisses_on_esc(self):
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        win.getch.side_effect = [27]  # Esc
+        modal.show(win)
+        # Modal exited the loop, so getch was called exactly once.
+        self.assertEqual(win.getch.call_count, 1)
+
+    def test_help_modal_dismisses_on_enter(self):
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        win.getch.side_effect = [ord('\n')]
+        modal.show(win)
+        self.assertEqual(win.getch.call_count, 1)
+
+    def test_help_modal_dismisses_on_click_in_ok_button(self):
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        modal.render(win)
+        x_start, x_end, btn_y, _ = modal.button_bar.button_positions[0]
+        midx = (x_start + x_end) // 2
+
+        win.getch.side_effect = [curses.KEY_MOUSE]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, midx, btn_y, 0, curses.BUTTON1_CLICKED),
+        ):
+            modal.show(win)
+        self.assertEqual(win.getch.call_count, 1)
+
+    def test_help_modal_ignores_outside_click(self):
+        """Click outside any button keeps the loop alive; a follow-up key terminates."""
+        from tnc.dialog import HelpModal
+        modal = HelpModal()
+        win = mock.MagicMock()
+        win.getmaxyx.return_value = (40, 100)
+        # Outside click at (0, 0), then Esc.
+        win.getch.side_effect = [curses.KEY_MOUSE, 27]
+        with mock.patch(
+            'curses.getmouse',
+            return_value=(0, 0, 0, 0, curses.BUTTON1_CLICKED),
+        ):
+            modal.show(win)
+        # 2 getch calls — outside click ignored, then Esc terminates.
+        self.assertEqual(win.getch.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -19,6 +19,7 @@ from tnc.dialog import (
     CursesOverwriteHandler,
     SelectionDialog,
     confirm_dialog,
+    help_dialog,
     input_dialog,
     show_error_dialog,
     show_summary,
@@ -248,6 +249,7 @@ class App:
             Action.TOGGLE_MOUSE: self._toggle_mouse,
             Action.TOGGLE_MOUSE_SWAP: self._toggle_mouse_swap,
             Action.MENU: self._toggle_menu_dropdown,
+            Action.HELP: self._show_help,
             # Permission operations
             Action.CHMOD: self._prompt_chmod,
             Action.CHOWN: self._prompt_chown,
@@ -990,6 +992,10 @@ class App:
         self.menu.dropdown_open = not self.menu.dropdown_open
         if self.menu.dropdown_open:
             self.menu.selected_item = 0
+
+    def _show_help(self) -> None:
+        """F1: open the keybindings help modal (issue #78)."""
+        help_dialog(self.stdscr)
 
     def _toggle_mouse_swap(self) -> None:
         """Toggle mouse button swap (for left-handed users) and save to config."""

--- a/tnc/app.py
+++ b/tnc/app.py
@@ -69,6 +69,7 @@ class Action(Enum):
     TOGGLE_MOUSE = auto()
     TOGGLE_MOUSE_SWAP = auto()
     MENU = auto()  # Toggle menu dropdown
+    HELP = auto()  # F1: show keybindings dialog (issue #78)
     CHMOD = auto()  # Change permissions
     CHOWN = auto()  # Change ownership
     # Panel-specific sort actions
@@ -613,7 +614,13 @@ class App:
         Returns:
             Action if key was handled, None if not an operation key.
         """
-        if key == curses.KEY_F3:
+        # F1 / F2 (issue #78): mc parity. F1 opens the keybindings help
+        # dialog; F2 aliases F9's menu-dropdown toggle.
+        if key == curses.KEY_F1:
+            return Action.HELP
+        elif key == curses.KEY_F2:
+            return Action.MENU
+        elif key == curses.KEY_F3:
             return Action.VIEW
         elif key == curses.KEY_F4:
             return Action.EDIT

--- a/tnc/dialog.py
+++ b/tnc/dialog.py
@@ -2273,3 +2273,107 @@ def input_dialog(
     dialog = InputDialog(title, prompt, default_value)
     result = dialog.show(win)
     return result if result is not None else ''
+
+
+# F1 Help dialog content (issue #78). Hard-coded rather than generated
+# from the keybinding registry — refactoring handle_key to a registry
+# is OOS for v1. Keep this in lockstep with tnc/app.py:handle_key and
+# the CLAUDE.md "Key Bindings (Target)" section.
+HELP_CONTENT = (
+    ('Navigation', (
+        ('Tab', 'Switch active panel'),
+        ('Arrows', 'Navigate'),
+        ('Enter', 'Enter dir / open file'),
+        ('Alt+Left / Alt+Right', 'Back / forward through history'),
+        ('/', 'Quick search in panel'),
+        ('Esc', 'Close dialog / cancel search'),
+    )),
+    ('File operations', (
+        ('F3', 'View'),
+        ('F4', 'Edit'),
+        ('Shift+F4', 'Create new file'),
+        ('F5', 'Copy to other panel'),
+        ('F6', 'Move to other panel'),
+        ('F7', 'Make directory'),
+        ('F8', 'Delete (with confirmation)'),
+    )),
+    ('Selection', (
+        ('Insert', 'Toggle selection on current entry'),
+        ('+', 'Select by pattern'),
+        ('-', 'Deselect by pattern'),
+        ('*', 'Invert selection'),
+    )),
+    ('Sort', (
+        ('Shift+F3', 'Cycle sort order'),
+        ('Ctrl+F3', 'Toggle reverse sort'),
+    )),
+    ('Other', (
+        ('F1', 'This help'),
+        ('F2 / F9', 'Menu (dropdown)'),
+        ('F10', 'Quit'),
+        ('Alt+F3', 'Calculate directory size'),
+        ('Alt+Enter', 'Insert filename into command line'),
+        ('Alt+O', 'Open in Finder (macOS only)'),
+    )),
+)
+
+
+class HelpModal(Modal):
+    """F1 keybindings help dialog (issue #78).
+
+    Displays HELP_CONTENT grouped by section with an OK button. Any
+    keystroke or click on OK dismisses; outside-modal clicks are
+    ignored (consistent with the other modals from issue #16).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title = 'Keyboard Shortcuts'
+        longest = max(
+            len(f'  {key:22s}  {desc}')
+            for _, items in HELP_CONTENT for key, desc in items
+        )
+        self._width = max(longest + 4, len(self.title) + 6, 50)
+        self.button_bar = ButtonBar(
+            buttons=[Button(label='OK', shortcut='', value=None)],
+            focused=0,
+        )
+
+    def _build_body(self) -> list[str]:
+        lines: list[str] = []
+        for i, (section, items) in enumerate(HELP_CONTENT):
+            if i > 0:
+                lines.append('')
+            lines.append(section)
+            for key, desc in items:
+                lines.append(f'  {key:22s}  {desc}')
+        lines.append('')  # reserved for button bar overlay
+        return lines
+
+    def render(self, win: Any) -> None:
+        body = self._build_body()
+        box_y, box_x = draw_modal(win, self.title, body, width=self._width)
+        btn_y = box_y + 3 + len(body) - 1
+        self.button_bar.render(
+            win, y=btn_y, x_start=box_x + 2, total_width=self._width - 4,
+            base_attr=get_attr(PAIR_DIALOG),
+        )
+        win.refresh()
+
+    def handle_key(self, key: int) -> None:
+        # Any key dismisses (Esc, Enter, OK shortcut, etc.).
+        # Matches ErrorModal / SummaryModal back-compat semantics.
+        self.set_result(None)
+
+    def handle_click(self, x: int, y: int, button_state: int) -> None:
+        if not (button_state & curses.BUTTON1_CLICKED):
+            return
+        for x_start, x_end, btn_y, _value in self.button_bar.button_positions:
+            if y == btn_y and x_start <= x < x_end:
+                self.set_result(None)
+                return
+
+
+def help_dialog(win: Any) -> None:
+    """Show the F1 keybindings help modal."""
+    HelpModal().show(win)

--- a/tnc/function_bar.py
+++ b/tnc/function_bar.py
@@ -34,11 +34,17 @@ class FunctionBar:
     - Label (e.g., "View") in black on cyan
     """
 
-    # Keys to display in order (tuple since immutable)
-    _DISPLAY_KEYS = ('F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10')
+    # Keys to display in order (tuple since immutable). Issue #78 added
+    # F1 (Help) and F2 (Menu) for mc parity; the bar now shows 10 buttons.
+    _DISPLAY_KEYS = (
+        'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10',
+    )
 
-    # Default labels for each function key
+    # Default labels for each function key. F2 and F9 share the 'Menu'
+    # label because they dispatch the same Action.MENU — see issue #78.
     _DEFAULT_LABELS = {
+        'F1': 'Help',
+        'F2': 'Menu',
         'F3': 'View',
         'F4': 'Edit',
         'F5': 'Copy',
@@ -127,8 +133,10 @@ class FunctionBar:
         # Clear the line first with label background
         safe_addstr(win, y, 0, ' ' * width, label_attr)
 
-        # Button definitions: (key, action)
+        # Button definitions: (key, action). Issue #78 added F1/F2.
         buttons = [
+            ('F1', Action.HELP),
+            ('F2', Action.MENU),
             ('F3', Action.VIEW),
             ('F4', Action.EDIT),
             ('F5', Action.COPY),


### PR DESCRIPTION
## Summary
- Function bar now shows 10 buttons (F1–F10) for mc parity. F1 opens a new keybindings help dialog; F2 aliases F9's `Action.MENU`.
- New `HelpModal` (subclass of `Modal` from #16) renders `HELP_CONTENT` grouped into 5 sections (Navigation, File operations, Selection, Sort, Other) with a focused OK button. Any key, click on OK, or Esc dismisses; outside-modal clicks are ignored.
- `CLAUDE.md` "Key Bindings (Target)" section updated to include F1 and F2.

## Related Issue
Closes #78

## Changes Made
- `tnc/app.py` — new `Action.HELP` enum value; F1 → `Action.HELP`, F2 → `Action.MENU` in `handle_key`; new `_show_help` handler registered in `_action_handlers`.
- `tnc/dialog.py` — new `HELP_CONTENT` tuple, `HelpModal` class, `help_dialog(win)` wrapper.
- `tnc/function_bar.py` — `_DISPLAY_KEYS` extended to 10 entries; `_DEFAULT_LABELS` adds `'F1': 'Help'`, `'F2': 'Menu'`; `buttons` list in `render()` prefixed with F1/F2.
- `CLAUDE.md` — F1/F2 lines added to keybindings target.
- `tests/test_help_dialog.py` *(new)* — 9 tests: F1/F2 routing + Action.HELP existence; HelpModal rendering, dismiss-on-Esc/Enter/click-OK, outside-click-ignored.
- `tests/test_function_bar*.py` — updated cell-position assertions for new 10-button layout (cell_width=8 at width=80).

## Architectural decisions
- **Hard-coded `HELP_CONTENT`** rather than generated from a keybinding registry. Refactoring `handle_key` to a registry was OOS for v1 — explicitly noted.
- **F2 aliases F9** (both dispatch `Action.MENU` to the existing `_toggle_menu_dropdown` handler). Avoids duplicating menu-toggle code.
- **Both labeled "Menu"** in the bar — F2 and F9 share the action so they share the label. Misleading to differentiate.
- **Layout overflow at width=80 accepted**: 10 buttons → cell_width=8, longer than `' F8Delete'` (9 chars). The `max(0, …)` clamp from #18 prevents negative offsets; the label overflows visually by 1 char into F9's cell. Wider terminals (≥120 cols) fit cleanly. Acceptance criteria explicitly accept this graceful degradation.

## Out of scope
- mc-style configurable user menu (`~/.config/mc/menu`).
- Help-content scrolling / pagination / search.
- Localization.
- Refactoring `handle_key` to a registry.
- Renaming F9's label.
- Changing F-key labels to mc's shorter style ("1Help", etc.).

## Testing Done
- [x] **T1 RED→GREEN:** F1/F2 routing tests — failed with `Action.NONE != Action.MENU`, then green after wiring.
- [x] **T2 RED→GREEN:** HelpModal tests — failed with ImportError, then green after class implementation. 6 tests cover content, section headers, Esc/Enter/click-OK dismiss, outside-click-ignored.
- [x] **T3 RED→GREEN:** function bar count tests — failed expecting 8 buttons, then green after extending to 10. 5 mouse tests + 2 layout tests updated for new cell math.
- [x] **Full suite:** `python3.14 -m unittest discover -s tests` — 1217 ran, only the 4 pre-existing baseline failures remain. **No new failures.**
- [x] **Chrome smoke** in ttyd:
  - Function bar shows `F1Help F2Menu F3View F4Edit F5Copy F6Move F7Mkdir F8Delete F9Menu F10Quit`.
  - F1 opens HelpModal with all 5 sections + `[< OK >]` button focused.
  - F2 opens the Left dropdown menu (same as F9 manually verified).

## Breaking Changes
None. Existing keybindings and dialogs unchanged. F1/F2 were unbound before.

## Checklist
- [x] Code follows project conventions (zero deps, stdlib only, TDD)
- [x] Tests added (9 new in test_help_dialog.py)
- [x] CLAUDE.md updated
- [x] No secrets committed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)