### PR TITLE
fix(function_bar): anchor F1 left and F10 right to remove edge cyan strips (#80)

### DIFF
--- a/tests/test_function_bar_mouse.py
+++ b/tests/test_function_bar_mouse.py
@@ -426,5 +426,71 @@ class TestFunctionBarLabelCentering(unittest.TestCase):
         self.assertEqual(bar.action_at_point(63), Action.DELETE)
 
 
+class TestFunctionBarEdgeAnchoring(unittest.TestCase):
+    """Issue #80: the first button anchors to col 0 (no left padding)
+    and the last button anchors to its cell's right edge (no trailing
+    pad inside the cell). Middle buttons keep #18's centering."""
+
+    def _capture_addstr_calls(self, bar: FunctionBar, width: int):
+        calls: list[tuple[int, str]] = []
+        win = mock.MagicMock()
+
+        def fake_addstr(_y, x, text, *_args, **_kwargs):
+            calls.append((x, text))
+
+        win.addstr.side_effect = fake_addstr
+        bar.render(win, y=0, width=width)
+        return [(x, t) for (x, t) in calls if not (x == 0 and len(t) == width)]
+
+    def test_first_button_renders_at_col_zero_at_width_145(self):
+        """At width=145 (cell_width=14), F1 (' F1Help', 7 chars) used to
+        render centered at col 3 with cols 0-2 cyan-padding. Now it
+        anchors to col 0 — no leading cyan strip before F1."""
+        bar = FunctionBar()
+        calls = self._capture_addstr_calls(bar, width=145)
+        f1_calls = [(x, t) for (x, t) in calls if t == ' F1']
+        self.assertEqual(len(f1_calls), 1, f1_calls)
+        x, _ = f1_calls[0]
+        self.assertEqual(x, 0, f'F1 should anchor to col 0, got x={x}')
+
+    def test_first_button_renders_at_col_zero_at_width_80(self):
+        bar = FunctionBar()
+        calls = self._capture_addstr_calls(bar, width=80)
+        f1_calls = [(x, t) for (x, t) in calls if t == ' F1']
+        self.assertEqual(len(f1_calls), 1)
+        self.assertEqual(f1_calls[0][0], 0)
+
+    def test_last_button_anchors_to_cell_right_edge_at_width_145(self):
+        """At width=145, cell_width=14, F10 cell [126, 140). Label
+        ' F10Quit' (8 chars). Right-anchored: text_start = 140 - 8 = 132."""
+        bar = FunctionBar()
+        calls = self._capture_addstr_calls(bar, width=145)
+        f10_calls = [(x, t) for (x, t) in calls if t == ' F10']
+        self.assertEqual(len(f10_calls), 1, f10_calls)
+        x, _ = f10_calls[0]
+        self.assertEqual(x, 132, f'F10 should right-anchor at col 132, got x={x}')
+
+    def test_middle_buttons_remain_centered_at_width_145(self):
+        """F2..F9 keep issue #18's centering; this regression-locks that
+        the edge-anchor change doesn't accidentally affect middle buttons."""
+        bar = FunctionBar()
+        calls = self._capture_addstr_calls(bar, width=145)
+        # cell_width = 14. F5 (' F5Copy', 7 chars) at index 4:
+        # cell [56, 70). Centered: 56 + (14-7)//2 = 56 + 3 = 59.
+        f5_calls = [(x, t) for (x, t) in calls if t == ' F5']
+        self.assertEqual(len(f5_calls), 1)
+        self.assertEqual(f5_calls[0][0], 59)
+
+    def test_button_positions_unchanged_by_edge_anchoring(self):
+        """Edge anchoring is a render-only change — the click hit-region
+        table (button_positions) is the same as before."""
+        bar = FunctionBar()
+        win = mock.MagicMock()
+        bar.render(win, y=0, width=80)
+        expected_starts = [i * 8 for i in range(10)]
+        actual_starts = [s for s, _, _ in bar.button_positions]
+        self.assertEqual(actual_starts, expected_starts)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tnc/function_bar.py
+++ b/tnc/function_bar.py
@@ -167,15 +167,27 @@ class FunctionBar:
             key_text = f' {key}'
             label_text = label
 
-            # Center the label within its cell. Issue #18: left-aligned
-            # labels left trailing cyan padding sitting right next to the
-            # next button's label, so a click in that gap landed in the
-            # previous cell and triggered the wrong action. Centering puts
-            # the visible text in the middle of its clickable region. The
-            # max(0, ...) clamp keeps narrow terminals (label wider than
-            # cell) rendering at start_x.
+            # Position the label within its cell:
+            #   - First button: anchored to col 0 (no leading cyan strip).
+            #   - Last button:  anchored to the right edge of its cell
+            #                   (no trailing cyan strip after the label).
+            #   - Middle buttons: centered (issue #18 — a click just before
+            #                     the visible label still resolves to that
+            #                     button instead of the previous cell's
+            #                     trailing pad).
+            # Issue #80: the centering created visible cyan strips at the
+            # left and right ends of the bar that looked like cut-off
+            # content. End-anchoring removes them while preserving the
+            # click-region invariants (button_positions is unchanged).
+            # The max(0, ...) clamp keeps narrow terminals (label wider
+            # than cell) rendering at start_x for middle buttons.
             text_len = len(key_text) + len(label_text)
-            text_start = start_x + max(0, (cell_width - text_len) // 2)
+            if i == 0:
+                text_start = start_x
+            elif i == len(buttons) - 1:
+                text_start = max(start_x, end_x - text_len)
+            else:
+                text_start = start_x + max(0, (cell_width - text_len) // 2)
 
             # Check if this button should be highlighted (visual feedback)
             if self.highlight_button == key:


### PR DESCRIPTION
## Summary
- F1 anchors to col 0 (no leading cyan strip before \`F1Help\`).
- F10 anchors to its cell's right edge (no trailing cyan strip after \`F10Quit\`).
- F2–F9 keep issue #18's centering (clicks just before a visible label still resolve to that button).

## Related Issue
Closes #80

## Root cause
At width=145 (cell_width=14), F1's \`' F1Help'\` (7 chars) rendered centered at col 3, leaving cols 0–2 as cyan padding. F10 had the symmetric problem on the right. Visually the bar looked like content was clipped.

## Changes
- \`tnc/function_bar.py\` — render() now branches on button index: first button left-anchors at \`start_x\`, last right-anchors at \`end_x - text_len\`, middle buttons keep the centering math from #18. \`button_positions\` (click hit-region table) is unchanged.
- \`tests/test_function_bar_mouse.py\` — \`TestFunctionBarEdgeAnchoring\` (5 tests): F1 at col 0 at widths 80 / 145, F10 right-anchored, F5 still centered (regression-locks middle behavior), button_positions invariant.

## Testing
- [x] **RED:** new tests fail with F1 at col 3 (was 0 expected) and F10 at col 129 (was 132 expected).
- [x] **GREEN:** \`tests.test_function_bar*\` — 49/49 pass.
- [x] **Full suite:** 1222 ran, only the 4 pre-existing baseline failures.
- [x] **Chrome smoke:** zoomed screenshots confirm \`F1Help\` at col 0 and \`F10Quit\` ending at the rightmost column.

## Breaking Changes
None. Click hit-regions and keybindings unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)